### PR TITLE
Adds server options

### DIFF
--- a/src/Grapevine/IRestServer.cs
+++ b/src/Grapevine/IRestServer.cs
@@ -32,12 +32,6 @@ namespace Grapevine
     public interface IRestServer : ILocals, IDisposable
     {
         /// <summary>
-        /// Gets or sets a value that indicates whether autoscan is enabled on this router.
-        /// </summary>
-        /// <value>true</value>
-        bool EnableAutoScan { get; set; }
-
-        /// <summary>
         /// Gets the list of all ContentFolder objects used for serving static content.
         /// </summary>
         /// <value></value>
@@ -56,15 +50,21 @@ namespace Grapevine
         HttpContextFactory HttpContextFactory { get; set; }
 
         /// <summary>
+        /// Gets a value that indicates whether the server is currently listening.
+        /// </summary>
+        bool IsListening { get; }
+
+        /// <summary>
         /// Gets the logger for this IRestServer object.
         /// </summary>
         /// <value></value>
         ILogger<IRestServer> Logger { get; }
 
         /// <summary>
-        /// Gets a value that indicates whether the server is currently listening.
+        /// Gets the server options object used by this IRestServer object
         /// </summary>
-        bool IsListening { get; }
+        /// <value></value>
+        ServerOptions Options { get; }
 
         /// <summary>
         /// Gets the Uniform Resource Identifier (URI) prefixes handled by this IRestServer object.

--- a/src/Grapevine/RestServer.cs
+++ b/src/Grapevine/RestServer.cs
@@ -8,17 +8,17 @@ namespace Grapevine
 {
     public abstract class RestServerBase : Locals, IRestServer
     {
-        public bool EnableAutoScan { get; set; } = true;
-
         public IList<IContentFolder> ContentFolders { get; } = new List<IContentFolder>();
 
         public IList<GlobalResponseHeader> GlobalResponseHeaders { get; set; } = new List<GlobalResponseHeader>();
 
         public HttpContextFactory HttpContextFactory { get; set; } = (context, server, token) => new HttpContext(context, server, token);
 
+        public virtual bool IsListening { get; }
+
         public ILogger<IRestServer> Logger { get; protected set; }
 
-        public virtual bool IsListening { get; }
+        public ServerOptions Options { get; } = new ServerOptions();
 
         public virtual HttpListenerPrefixCollection Prefixes { get; }
 
@@ -135,7 +135,7 @@ namespace Grapevine
                 BeforeStarting?.Invoke(this);
 
                 // 3. Optionally autoscan for routes
-                if (Router.RoutingTable.Count == 0 && EnableAutoScan)
+                if (Router.RoutingTable.Count == 0 && Options.EnableAutoScan)
                     Router.Register(RouteScanner.Scan());
 
                 // 4. Configure and start the listener

--- a/src/Grapevine/ServerOptions.cs
+++ b/src/Grapevine/ServerOptions.cs
@@ -1,0 +1,11 @@
+namespace Grapevine
+{
+    public class ServerOptions
+    {
+        /// <summary>
+        /// Gets or sets a value that indicates whether autoscan is enabled on this router.
+        /// </summary>
+        /// <value>true</value>
+        public bool EnableAutoScan { get; set; } = true;
+    }
+}


### PR DESCRIPTION
This moves `EnableAutoScan` to a new class called `ServerOptions`, much the same way a lot of options were moved over to `RouterOptions`.

Removing these properties from the interface in both cases and moving them into separate classes with the suffix Options is intended to both alleviate implementers of those interface from having to implement them, but also to drive home the point that they are **optional**. While the core classes (at least for now) honor those options, other implementation may not need to or want to, and that's okay.