### PR TITLE
More ServerOptions

### DIFF
--- a/src/Grapevine/IRestServer.cs
+++ b/src/Grapevine/IRestServer.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 
@@ -20,15 +19,6 @@ namespace Grapevine
     /// <param name="context"></param>
     public delegate Task RequestReceivedAsyncEventHandler(IHttpContext context);
 
-    /// <summary>
-    /// Delegate for the <see cref="IRestServer.HttpContextFactory"/> factory
-    /// </summary>
-    /// <param name="context"></param>
-    /// <param name="server"></param>
-    /// <param name="token"></param>
-    /// <returns></returns>
-    public delegate IHttpContext HttpContextFactory(HttpListenerContext context, IRestServer server, CancellationToken token);
-
     public interface IRestServer : ILocals, IDisposable
     {
         /// <summary>
@@ -42,12 +32,6 @@ namespace Grapevine
         /// </summary>
         /// <value></value>
         IList<GlobalResponseHeader> GlobalResponseHeaders { get; set; }
-
-        /// <summary>
-        /// Gets or sets the delegate that creates IHttpContext objects.
-        /// </summary>
-        /// <value></value>
-        HttpContextFactory HttpContextFactory { get; set; }
 
         /// <summary>
         /// Gets a value that indicates whether the server is currently listening.

--- a/src/Grapevine/RestServer.cs
+++ b/src/Grapevine/RestServer.cs
@@ -12,8 +12,6 @@ namespace Grapevine
 
         public IList<GlobalResponseHeader> GlobalResponseHeaders { get; set; } = new List<GlobalResponseHeader>();
 
-        public HttpContextFactory HttpContextFactory { get; set; } = (context, server, token) => new HttpContext(context, server, token);
-
         public virtual bool IsListening { get; }
 
         public ILogger<IRestServer> Logger { get; protected set; }
@@ -25,6 +23,12 @@ namespace Grapevine
         public IRouter Router { get; set; }
 
         public IRouteScanner RouteScanner { get; set; }
+
+        /// <summary>
+        /// Gets or sets the CancellationTokeSource for this RestServer object.
+        /// </summary>
+        /// <value></value>
+        protected CancellationTokenSource TokenSource { get; set; }
 
         public abstract event ServerEventHandler AfterStarting;
         public abstract event ServerEventHandler AfterStopping;
@@ -41,12 +45,6 @@ namespace Grapevine
 
     public class RestServer : RestServerBase
     {
-        /// <summary>
-        /// Gets or sets the CancellationTokeSource for this RestServer object.
-        /// </summary>
-        /// <value></value>
-        protected CancellationTokenSource TokenSource { get; set; }
-
         /// <summary>
         /// The thread that listens for incoming requests.
         /// </summary>
@@ -244,7 +242,7 @@ namespace Grapevine
         protected async void RequestHandlerAsync(object state)
         {
             // 1. Create context
-            var context = HttpContextFactory(state as HttpListenerContext, this, TokenSource.Token);
+            var context = Options.HttpContextFactory(state, this, TokenSource.Token);
             Logger.LogTrace($"{context.Id} : Request Received {context.Request.Name}");
 
             // 2. Execute OnRequest event handlers

--- a/src/Grapevine/ServerOptions.cs
+++ b/src/Grapevine/ServerOptions.cs
@@ -1,5 +1,17 @@
+using System.Net;
+using System.Threading;
+
 namespace Grapevine
 {
+    /// <summary>
+    /// Delegate for the <see cref="ServerOptions.HttpContextFactory"/> factory
+    /// </summary>
+    /// <param name="context"></param>
+    /// <param name="server"></param>
+    /// <param name="token"></param>
+    /// <returns></returns>
+    public delegate IHttpContext HttpContextFactory(object state, IRestServer server, CancellationToken token);
+
     public class ServerOptions
     {
         /// <summary>
@@ -7,5 +19,11 @@ namespace Grapevine
         /// </summary>
         /// <value>true</value>
         public bool EnableAutoScan { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets the delegate that creates IHttpContext objects.
+        /// </summary>
+        /// <value></value>
+        public HttpContextFactory HttpContextFactory { get; set; }  = (state, server, token) => new HttpContext(state as HttpListenerContext, server, token);
     }
 }


### PR DESCRIPTION
- Relocates `HttpContextFactory` to `ServerOptions`
- Relocates `CancellationTokenSource` to `RestServerBase`

The goal is to have as much of the non-`HttpListener`-implementation-specific code as possible out of the `RestServer` class.