### PR TITLE
Improvements to RestServerBuilder

### DIFF
--- a/src/Grapevine/Grapevine.csproj
+++ b/src/Grapevine/Grapevine.csproj
@@ -27,6 +27,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
@@ -49,8 +50,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="..\..\LICENSE" Pack="true" Visible="false" PackagePath=""/>
-    <None Include="..\..\grapevine.png" Pack="true" PackagePath="\"/>
+    <None Include="..\..\LICENSE" Pack="true" Visible="false" PackagePath="" />
+    <None Include="..\..\grapevine.png" Pack="true" PackagePath="\" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Grapevine/Grapevine.csproj
+++ b/src/Grapevine/Grapevine.csproj
@@ -5,13 +5,14 @@
     <PackageId>Grapevine</PackageId>
     <PackageVersion>$(Version)</PackageVersion>
     <Authors>Scott Offen</Authors>
+    <Copyright>© 2014-2019 Scott Offen</Copyright>
     <Owners>Scott Offen</Owners>
     <Description>Fast, unopinionated, embeddable, minimalist REST framework for .NET</Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageTags>rest http api web router client server express json xml embedded</PackageTags>
     <AssemblyVersion>$(Version)</AssemblyVersion>
     <FileVersion>$(Version)</FileVersion>
-    <Version>5.0.0-rc.4</Version>
+    <Version>5.0.0-rc.5</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <RepositoryUrl>https://github.com/scottoffen/grapevine</RepositoryUrl>
@@ -48,13 +49,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="..\..\LICENSE">
-      <Pack>True</Pack>
-      <PackagePath></PackagePath>
-    </None>
-  </ItemGroup>
-
-  <ItemGroup>
+    <None Include="..\..\LICENSE" Pack="true" Visible="false" PackagePath=""/>
     <None Include="..\..\grapevine.png" Pack="true" PackagePath="\"/>
   </ItemGroup>
 

--- a/src/Grapevine/IContentFolder.cs
+++ b/src/Grapevine/IContentFolder.cs
@@ -1,10 +1,17 @@
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Grapevine
 {
     public interface IContentFolder
     {
+        /// <summary>
+        /// Returns a list of relative paths for all files and folders in the directory
+        /// </summary>
+        /// <value></value>
+        IList<string> DirectoryListing { get; }
+
         /// <summary>
         /// Gets or sets the default file to return when a directory is requested
         /// </summary>
@@ -18,7 +25,7 @@ namespace Grapevine
         /// <summary>
         /// Gets the folder used when scanning for static content requests
         /// </summary>
-        string FolderPath { get; }
+        string FolderPath { get; set; }
 
         /// <summary>
         /// If the file specified in the path info of the request matches a file in the content folder, that file will be sent in the response.
@@ -40,5 +47,13 @@ namespace Grapevine
         /// </summary>
         /// <value>Action<IHttpContext></value>
         Func<IHttpContext, Task> FileNotFoundHandler { get; set; }
+    }
+
+    public static class IContentFolderExtensions
+    {
+        public static void Add(this ICollection<IContentFolder> collection, string folderPath)
+        {
+            collection.Add(new ContentFolder(folderPath));
+        }
     }
 }

--- a/src/Grapevine/RestServerBuilder.cs
+++ b/src/Grapevine/RestServerBuilder.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -9,65 +10,71 @@ namespace Grapevine
 {
     public class RestServerBuilder
     {
-        private IServiceCollection _services;
-        private Action<IServiceCollection> _configureServices;
-        private Action<IRestServer> _configureServer;
+        public IConfiguration Configuration { get; set; }
+        public IServiceCollection Services { get; set; }
+        public Action<IServiceCollection> ConfigureServices { get; set; }
+        public Action<IRestServer> ConfigureServer { get; set; }
 
-        public RestServerBuilder() : this(new ServiceCollection(), null, null) { }
+        public RestServerBuilder() : this(null, null, null, null) { }
 
-        public RestServerBuilder(IServiceCollection services) : this(services, null, null) { }
+        public RestServerBuilder(IServiceCollection services) : this(services, null, null, null) { }
 
-        public RestServerBuilder(Func<IServiceCollection> serviceInitializer) : this(serviceInitializer, null, null) { }
+        public RestServerBuilder(IServiceCollection services, IConfiguration configuration) : this(services, configuration, null, null) { }
 
-        public RestServerBuilder(IServiceCollection services, Action<IServiceCollection> configureServices) : this(services, configureServices, null) { }
+        public RestServerBuilder(IServiceCollection services, IConfiguration configuration, Action<IServiceCollection> configureServices) : this(services, configuration, configureServices, null) { }
 
-        public RestServerBuilder(Func<IServiceCollection> serviceInitializer, Action<IServiceCollection> configureServices) : this(serviceInitializer, configureServices, null) { }
+        public RestServerBuilder(IServiceCollection services, IConfiguration configuration, Action<IRestServer> configureServer) : this(services, configuration, null, configureServer) { }
 
-        public RestServerBuilder(IServiceCollection services, Action<IRestServer> configureServer) : this(services, null, configureServer) { }
+        public RestServerBuilder(IServiceCollection services, Action<IServiceCollection> configureServices) : this(services, null, configureServices, null) { }
 
-        public RestServerBuilder(Func<IServiceCollection> serviceInitializer, Action<IRestServer> configureServer) : this(serviceInitializer, null, configureServer) { }
+        public RestServerBuilder(IServiceCollection services, Action<IRestServer> configureServer) : this(services, null, null, configureServer) { }
 
-        public RestServerBuilder(Func<IServiceCollection> serviceInitializer, Action<IServiceCollection> configureServices, Action<IRestServer> configureServer) : this(serviceInitializer.Invoke(), configureServices, configureServer) { }
+        public RestServerBuilder(IServiceCollection services, Action<IServiceCollection> configureServices, Action<IRestServer> configureServer) : this(services, null, configureServices, configureServer) { }
 
-        public RestServerBuilder(IServiceCollection services, Action<IServiceCollection> configureServices, Action<IRestServer> configureServer)
+        public RestServerBuilder(IServiceCollection services, IConfiguration configuration, Action<IServiceCollection> configureServices, Action<IRestServer> configureServer)
         {
-            _services = services;
-            _configureServices = configureServices;
-            _configureServer = configureServer;
+            Services = services ?? new ServiceCollection();
+            Configuration = configuration ?? GetDefaultConfiguration();
+            ConfigureServices = configureServices;
+            ConfigureServer = configureServer;
         }
 
         public IRestServer Build()
         {
-            _services.AddSingleton<IRestServer, RestServer>();
-            _services.AddSingleton<IRouter, Router>();
-            _services.AddSingleton<IRouteScanner, RouteScanner>();
-            _services.AddTransient<IContentFolder, ContentFolder>();
-            _services.AddLogging(configure => configure.AddConsole());
+            if (Configuration == null) Configuration = GetDefaultConfiguration();
 
-            _configureServices?.Invoke(_services);
+            Services.AddSingleton(typeof(IConfiguration), Configuration);
+            Services.AddSingleton<IRestServer, RestServer>();
+            Services.AddSingleton<IRouter, Router>();
+            Services.AddSingleton<IRouteScanner, RouteScanner>();
+            Services.AddTransient<IContentFolder, ContentFolder>();
 
-            var provider = _services.BuildServiceProvider();
+            ConfigureServices?.Invoke(Services);
+
+            var provider = Services.BuildServiceProvider();
 
             var server = provider.GetRequiredService<IRestServer>();
-            server.Router.Services = _services;
-            server.RouteScanner.Services = _services;
+            server.Router.Services = Services;
+            server.RouteScanner.Services = Services;
 
             var factory = provider.GetService<ILoggerFactory>();
             if (factory != null) server.SetDefaultLogger(factory);
 
-            // Add Server Global Response Header
             var assembly = GetType().Assembly.GetName();
             server.GlobalResponseHeaders.Add("Server", $"{assembly.Name}/{assembly.Version} ({RuntimeInformation.OSDescription})");
 
-            _configureServer?.Invoke(server);
+            ConfigureServer?.Invoke(server);
 
             return server;
         }
 
         public static RestServerBuilder UseDefaults()
         {
+            var config = GetDefaultConfiguration();
+
             Action<IServiceCollection> configServices = (services) =>
             {
+                services.AddLogging(configure => configure.AddConsole());
                 services.Configure<LoggerFilterOptions>(options => options.MinLevel = LogLevel.Trace);
             };
 
@@ -76,14 +83,37 @@ namespace Grapevine
                 server.Prefixes.Add("http://localhost:1234/");
             };
 
-            return new RestServerBuilder(new ServiceCollection(), configServices, configServer);
+            return new RestServerBuilder(new ServiceCollection(), config, configServices, configServer);
         }
 
         public static RestServerBuilder From<T>()
         {
             var type = typeof(T);
-            var obj = Activator.CreateInstance(type, new object[] { });
+
+            // Get the constructor
+            var constructor = type.GetConstructors().Where(c =>
+            {
+                var args = c.GetParameters();
+                return args.Count() == 1 && args.First().ParameterType == typeof(IConfiguration);
+            }).FirstOrDefault();
+
+            // Get the configuration
+            var config = GetDefaultConfiguration();
+
+            // Instanciate startup
+            var obj = (constructor != null)
+                ? Activator.CreateInstance(type, new object[] { config })
+                : Activator.CreateInstance(type, new object[] { });
+
             var methods = type.GetMethods(BindingFlags.Public | BindingFlags.Instance);
+
+            // Initialize Configuration: ReturnType(IConfiguration), Args(null)
+            var mci = methods.Where(m => m.ReturnParameter.ParameterType == typeof(IConfiguration) && m.GetParameters().Length == 0).FirstOrDefault();
+            Func<IConfiguration> configInitializer = () =>
+            {
+                if (mci == null) return config;
+                return (IConfiguration)mci.Invoke(obj, null);
+            };
 
             // Initialize Services: ReturnType(IServiceCollection), Args(null)
             var msi = methods.Where(m => m.ReturnParameter.ParameterType == typeof(IServiceCollection) && m.GetParameters().Length == 0).FirstOrDefault();
@@ -94,22 +124,59 @@ namespace Grapevine
             };
 
             // Configure Services: ReturnType(void), Arg[0](IServiceCollection)
-            var mcs = methods.Where(m => m.ReturnParameter.ParameterType == typeof(void) && m.GetParameters().Length == 1 && m.GetParameters()[0].ParameterType == typeof(IServiceCollection)).FirstOrDefault();
+            var mcs = methods.Where(m => m.ReturnParameter.ParameterType == typeof(void) && m.GetParameters().Length == 1 && m.GetParameters()[0].ParameterType == typeof(IServiceCollection));
             Action<IServiceCollection> configureServices = (s) =>
             {
-                if (mcs == null) return;
-                mcs.Invoke(obj, new object[] { s });
+                if (!mcs.Any()) return;
+                foreach (var method in mcs) method.Invoke(obj, new object[] { s });
             };
 
             // Configure Server: ReturnType(void), Arg[0](IRestServer)
-            var mcv = methods.Where(m => m.ReturnParameter.ParameterType == typeof(void) && m.GetParameters().Length == 1 && m.GetParameters()[0].ParameterType == typeof(IRestServer)).FirstOrDefault();
+            var mcr = methods.Where(m => m.ReturnParameter.ParameterType == typeof(void) && m.GetParameters().Length == 1 && m.GetParameters()[0].ParameterType == typeof(IRestServer));
             Action<IRestServer> configureServer = (s) =>
             {
-                if (mcs == null) return;
-                mcv.Invoke(obj, new object[] { s });
+                if (!mcr.Any()) return;
+                foreach (var method in mcr) method.Invoke(obj, new object[] { s });
             };
 
-            return new RestServerBuilder(serviceInitializer, configureServices, configureServer);
+            return new RestServerBuilder(serviceInitializer.Invoke(), configInitializer.Invoke(), configureServices, configureServer);
+        }
+
+        private static IConfiguration GetDefaultConfiguration()
+        {
+            var config = new ConfigurationBuilder()
+                .SetBasePath(System.IO.Directory.GetCurrentDirectory())
+                .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
+                .Build();
+
+            return config;
+        }
+    }
+
+    public static class RestServerBuilderExtensions
+    {
+        public static RestServerBuilder UseConfiguration(this RestServerBuilder builder, IConfiguration configuration)
+        {
+            builder.Configuration = configuration;
+            return builder;
+        }
+
+        public static RestServerBuilder BuildConfiguration(this RestServerBuilder builder, Func<IConfiguration> configurationBuilder)
+        {
+            builder.Configuration = configurationBuilder.Invoke();
+            return builder;
+        }
+
+        public static RestServerBuilder UseContainer(this RestServerBuilder builder, IServiceCollection services)
+        {
+            builder.Services = services;
+            return builder;
+        }
+
+        public static RestServerBuilder BuildContainer(this RestServerBuilder builder, Func<IServiceCollection> servicesBuilder)
+        {
+            builder.Services = servicesBuilder.Invoke();
+            return builder;
         }
     }
 }


### PR DESCRIPTION
- Adds configurations to `RestServerBuilder`. Provide a configuration or have one injected
- `RestServerBuilder` will invoke all matching methods to configure services and configure server
- `RestServerBuilder` properties are now public
- Adds `set;` to `IContentFolder.FolderPath`
- Adds public directory list to `IContentFolder`
- Adds extensions to `ICollection<IContentFolder>` to add from a string folder path