### PR TITLE
Adds Grapevine.Client

### DIFF
--- a/src/Grapevine/Client/HttpClientExtensions.cs
+++ b/src/Grapevine/Client/HttpClientExtensions.cs
@@ -1,0 +1,82 @@
+using System.Collections.Generic;
+using System.Net.Http;
+
+namespace Grapevine.Client
+{
+    public static class HttpClientExtensions
+    {
+        public static IRestRequestBuilder WithAuthentication(this HttpClient client, string scheme, string token)
+        {
+            var builder = new RestRequestBuilder(client);
+            return builder.WithAuthentication(scheme, token);
+        }
+
+        public static IRestRequestBuilder WithBasicAuthentication(this HttpClient client, string username, string password)
+        {
+            var builder = new RestRequestBuilder(client);
+            return builder.WithBasicAuthentication(username, password);
+        }
+
+        public static IRestRequestBuilder WithBasicAuthentication(this HttpClient client, string token)
+        {
+            var builder = new RestRequestBuilder(client);
+            return builder.WithBasicAuthentication(token);
+        }
+
+        public static IRestRequestBuilder WithContent(this HttpClient client, HttpContent content)
+        {
+            var builder = new RestRequestBuilder(client);
+            builder.Content = content;
+            return builder;
+        }
+
+        public static IRestRequestBuilder WithContent(this HttpClient client, string content)
+        {
+            var builder = new RestRequestBuilder(client);
+            builder.Content = new StringContent(content);
+            return builder;
+        }
+
+        public static IRestRequestBuilder WithHeader(this HttpClient client, string key, string value)
+        {
+            var builder = new RestRequestBuilder(client);
+            return builder.WithHeader(key, value);
+        }
+
+        public static IRestRequestBuilder WithHeaders(this HttpClient client, IEnumerable<KeyValuePair<string, string>> headers)
+        {
+            var builder = new RestRequestBuilder(client);
+            return builder.WithHeaders(headers);
+        }
+
+        public static IRestRequestBuilder WithOAuthBearerToken(this HttpClient client, string token)
+        {
+            var builder = new RestRequestBuilder(client);
+            return builder.WithOAuthBearerToken(token);
+        }
+
+        public static IRestRequestBuilder WithRequestTimeout(this HttpClient client, int seconds)
+        {
+            var builder = new RestRequestBuilder(client);
+            return builder.WithRequestTimeout(seconds);
+        }
+
+        public static IRestRequestBuilder WithRoute(this HttpClient client, string route)
+        {
+            var builder = new RestRequestBuilder(client);
+            return builder.WithRoute(route);
+        }
+
+        public static IRestRequestBuilder WithQueryParam(this HttpClient client, string key, string value)
+        {
+            var builder = new RestRequestBuilder(client);
+            return builder.WithQueryParam(key, value);
+        }
+
+        public static IRestRequestBuilder WithQueryParams(this HttpClient client, IEnumerable<KeyValuePair<string, string>> queryParams)
+        {
+            var builder = new RestRequestBuilder(client);
+            return builder.WithQueryParams(queryParams);
+        }
+    }
+}

--- a/src/Grapevine/Client/HttpResponseMessageExtensions.cs
+++ b/src/Grapevine/Client/HttpResponseMessageExtensions.cs
@@ -1,0 +1,33 @@
+using System.IO;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace Grapevine.Client
+{
+    public static class HttpResponseMessageExtensions
+    {
+        public static async Task<string> GetResponseStringAsync(this Task<HttpResponseMessage> taskResponseMessage)
+        {
+            var response = await taskResponseMessage;
+            return (response.IsSuccessStatusCode)
+                ? await response.Content.ReadAsStringAsync().ConfigureAwait(false)
+                : default;
+        }
+
+        public static async Task<Stream> GetResponseStreamAsync(this Task<HttpResponseMessage> taskResponseMessage)
+        {
+            var response = await taskResponseMessage;
+            return (response.IsSuccessStatusCode)
+                ? await response.Content.ReadAsStreamAsync().ConfigureAwait(false)
+                : default;
+        }
+
+        public static async Task<byte[]> GetResponseBytesAsync(this Task<HttpResponseMessage> taskResponseMessage)
+        {
+            var response = await taskResponseMessage;
+            return (response.IsSuccessStatusCode)
+                ? await response.Content.ReadAsByteArrayAsync().ConfigureAwait(false)
+                : default;
+        }
+    }
+}

--- a/src/Grapevine/Client/IRestRequestBuilder.cs
+++ b/src/Grapevine/Client/IRestRequestBuilder.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Grapevine.Client
+{
+    public interface IRestRequestBuilder
+    {
+        HttpContent Content { get; set; }
+
+        QueryParams QueryParams { get; set; }
+
+        HttpRequestMessage Request { get; }
+
+        string Route { get; set; }
+
+        TimeSpan Timeout { get; set; }
+
+        Task<HttpResponseMessage> SendAsync(HttpMethod method, CancellationToken token);
+    }
+}

--- a/src/Grapevine/Client/IRestRequestBuilderExtensions.cs
+++ b/src/Grapevine/Client/IRestRequestBuilderExtensions.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Grapevine.Client
+{
+    public static class IRestRequestBuilderExtensions
+    {
+        public static IRestRequestBuilder WithAuthentication(this IRestRequestBuilder builder, string scheme, string token)
+        {
+            builder.Request.Headers.Authorization = new AuthenticationHeaderValue(scheme, token);
+            return builder;
+        }
+
+        public static IRestRequestBuilder WithBasicAuthentication(this IRestRequestBuilder builder, string username, string password)
+        {
+            var token = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{username}:{password}"));
+            return builder.WithBasicAuthentication(token);
+        }
+
+        public static IRestRequestBuilder WithBasicAuthentication(this IRestRequestBuilder builder, string token)
+        {
+            return builder.WithAuthentication("Basic", token);
+        }
+
+        public static IRestRequestBuilder WithContent(this IRestRequestBuilder builder, HttpContent content)
+        {
+            builder.Content = content;
+            return builder;
+        }
+
+        public static IRestRequestBuilder WithContent(this IRestRequestBuilder builder, string content)
+        {
+            builder.Content = new StringContent(content);
+            return builder;
+        }
+
+        public static IRestRequestBuilder WithHeader(this IRestRequestBuilder builder, string key, string value)
+        {
+            builder.Request.Headers.Add(key, value);
+            return builder;
+        }
+
+        public static IRestRequestBuilder WithHeaders(this IRestRequestBuilder builder, IEnumerable<KeyValuePair<string, string>> headers)
+        {
+            foreach (var header in headers) builder.Request.Headers.Add(header.Key, header.Value);
+            return builder;
+        }
+
+        public static IRestRequestBuilder WithOAuthBearerToken(this IRestRequestBuilder builder, string token)
+        {
+            return builder.WithAuthentication("Bearer", token);
+        }
+
+        public static IRestRequestBuilder WithRequestTimeout(this IRestRequestBuilder builder, int seconds)
+        {
+            builder.Timeout = TimeSpan.FromSeconds(seconds);
+            return builder;
+        }
+
+        public static IRestRequestBuilder WithRoute(this IRestRequestBuilder builder, string route)
+        {
+            builder.Route = route;
+            return builder;
+        }
+
+        public static IRestRequestBuilder WithQueryParam(this IRestRequestBuilder builder, string key, string value)
+        {
+            builder.QueryParams.Add(key, value);
+            return builder;
+        }
+
+        public static IRestRequestBuilder WithQueryParams(this IRestRequestBuilder builder, IEnumerable<KeyValuePair<string, string>> queryParams)
+        {
+            foreach (var param in queryParams) builder.QueryParams.Add(param.Key, param.Value);
+            return builder;
+        }
+
+        public static IRestRequestBuilder WithQueryParams(this IRestRequestBuilder builder, NameValueCollection queryParams)
+        {
+            foreach (string name in queryParams.Keys) builder.QueryParams.Add(name, queryParams.GetValue<string>(name));
+            return builder;
+        }
+
+        public static async Task<HttpResponseMessage> DeleteAsync(this IRestRequestBuilder builder)
+        {
+            return await builder.DeleteAsync(CancellationToken.None).ConfigureAwait(false);
+        }
+
+        public static async Task<HttpResponseMessage> DeleteAsync(this IRestRequestBuilder builder, CancellationToken token)
+        {
+            return await builder.SendAsync("Delete", token).ConfigureAwait(false);
+        }
+
+        public static async Task<HttpResponseMessage> GetAsync(this IRestRequestBuilder builder)
+        {
+            return await builder.GetAsync(CancellationToken.None).ConfigureAwait(false);
+        }
+
+        public static async Task<HttpResponseMessage> GetAsync(this IRestRequestBuilder builder, CancellationToken token)
+        {
+            return await builder.SendAsync("Get", token).ConfigureAwait(false);
+        }
+
+        public static async Task<HttpResponseMessage> PostAsync(this IRestRequestBuilder builder)
+        {
+            return await builder.SendAsync("Post", CancellationToken.None).ConfigureAwait(false);
+        }
+
+        public static async Task<HttpResponseMessage> PostAsync(this IRestRequestBuilder builder, HttpContent content)
+        {
+            builder.Content = content;
+            return await builder.SendAsync("Post", CancellationToken.None).ConfigureAwait(false);
+        }
+
+        public static async Task<HttpResponseMessage> PostAsync(this IRestRequestBuilder builder, CancellationToken token)
+        {
+            return await builder.SendAsync("Post", token).ConfigureAwait(false);
+        }
+
+        public static async Task<HttpResponseMessage> PostAsync(this IRestRequestBuilder builder, HttpContent content, CancellationToken token)
+        {
+            builder.Content = content;
+            return await builder.SendAsync("Post", token).ConfigureAwait(false);
+        }
+
+        public static async Task<HttpResponseMessage> PutAsync(this IRestRequestBuilder builder)
+        {
+            return await builder.SendAsync("Put", CancellationToken.None).ConfigureAwait(false);
+        }
+
+        public static async Task<HttpResponseMessage> PutAsync(this IRestRequestBuilder builder, HttpContent content)
+        {
+            builder.Content = content;
+            return await builder.SendAsync("Put", CancellationToken.None).ConfigureAwait(false);
+        }
+
+        public static async Task<HttpResponseMessage> PutAsync(this IRestRequestBuilder builder, CancellationToken token)
+        {
+            return await builder.SendAsync("Put", token).ConfigureAwait(false);
+        }
+
+        public static async Task<HttpResponseMessage> PutAsync(this IRestRequestBuilder builder, HttpContent content, CancellationToken token)
+        {
+            builder.Content = content;
+            return await builder.SendAsync("Put", token).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Grapevine/Client/QueryParams.cs
+++ b/src/Grapevine/Client/QueryParams.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Collections.Specialized;
+using System.Linq;
+
+namespace Grapevine.Client
+{
+    /// <summary>
+    /// Provides access the key/value pairs of the query string of the request
+    /// </summary>
+    public class QueryParams : NameValueCollection
+    {
+        public override string ToString()
+        {
+            return Count <= 0
+                ? string.Empty
+                : "?" + string.Join("&", (from key in AllKeys let value = Get(key) select Uri.EscapeDataString(key) + "=" + Uri.EscapeDataString(value)).ToArray());
+        }
+    }
+}

--- a/src/Grapevine/Client/RestRequestBuilder.cs
+++ b/src/Grapevine/Client/RestRequestBuilder.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Grapevine.Client
+{
+    public class RestRequestBuilder : IRestRequestBuilder
+    {
+        private readonly HttpClient _client;
+
+        public HttpContent Content { get; set; }
+
+        public QueryParams QueryParams { get; set; } = new QueryParams();
+
+        public HttpRequestMessage Request { get; } = new HttpRequestMessage();
+
+        public string Route { get; set; } = "";
+
+        public TimeSpan Timeout
+        {
+            get { return _client.Timeout; }
+            set { _client.Timeout = value; }
+        }
+
+        internal RestRequestBuilder(HttpClient client)
+        {
+            _client = client;
+        }
+
+        public async Task<HttpResponseMessage> SendAsync(HttpMethod method, CancellationToken token)
+        {
+            Request.Content = Content;
+            Request.Method = method;
+            Request.RequestUri = new Uri($"{_client.BaseAddress.ToString().TrimEnd('/')}/{Route.TrimStart('/')}{QueryParams.ToString()}");
+
+            return await _client.SendAsync(Request, HttpCompletionOption.ResponseContentRead, token).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Grapevine/RouteScanner.cs
+++ b/src/Grapevine/RouteScanner.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 
 namespace Grapevine
@@ -180,7 +181,7 @@ namespace Grapevine
                         .FirstOrDefault().ServiceLifetime
                     : ServiceLifetime.Scoped;
 
-                Services.Add(new ServiceDescriptor(type, type, lifetime));
+                Services.TryAdd(new ServiceDescriptor(type, type, lifetime));
             }
 
             Logger.LogTrace($"Scan of type {type.Name} complete: {routes.Count} total routes found");

--- a/src/Samples/Resources/GitHubClient.cs
+++ b/src/Samples/Resources/GitHubClient.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Specialized;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Grapevine;
+using Grapevine.Client;
+
+namespace Samples.Resources
+{
+    [RestResource(BasePath = "github")]
+    public class GitHubClient
+    {
+        private readonly HttpClient _client;
+
+        public GitHubClient(HttpClient client)
+        {
+            _client = client;
+        }
+
+        [RestRoute("Get", "/issues/{owner}/{repo}", Description = "Returns the JSON for the list of open issues returned for the specified repository")]
+        public async Task GetIssues(IHttpContext context)
+        {
+            var owner = context.Request.PathParameters["owner"];
+            var repo  = context.Request.PathParameters["repo"];
+            var query = (context.Request.QueryString.Count > 0)
+                ? context.Request.QueryString
+                : new NameValueCollection()
+                    {
+                        {"state", "open"},
+                        {"sort", "created"},
+                        {"direction", "desc"},
+                    };
+
+            await context.Response.SendResponseAsync(await _client.WithRoute($"/repos/{owner}/{repo}/issues")
+                .WithQueryParams(query)
+                .GetAsync()
+                .GetResponseStreamAsync()
+            );
+        }
+    }
+}

--- a/src/Samples/Samples.csproj
+++ b/src/Samples/Samples.csproj
@@ -5,6 +5,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
     <PackageReference Include="NLog" Version="4.7.6" />
     <PackageReference Include="NLog.Extensions.Logging" Version="1.7.0" />

--- a/src/Samples/Startup.cs
+++ b/src/Samples/Startup.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NLog.Extensions.Logging;
+using Samples.Resources;
 
 namespace Samples
 {
@@ -23,6 +24,13 @@ namespace Samples
             {
                 loggingBuilder.ClearProviders();
                 loggingBuilder.AddNLog(_configuration);
+            });
+
+            services.AddHttpClient<GitHubClient>(c =>
+            {
+                c.BaseAddress = new Uri("https://api.github.com/");
+                c.DefaultRequestHeaders.Add("Accept", "application/vnd.github.v3+json");
+                c.DefaultRequestHeaders.Add("User-Agent", "Grapevine-Client");
             });
         }
 


### PR DESCRIPTION
Grapevine.Client in version 5 is a significant departure from what it was before. In version 5 we embrace the use of `IHttpClientFactory` and the patterns described in [this and other articles](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/http-requests?view=aspnetcore-5.0), as this new feature is almost exactly what Grapevine.Client was intended to be. Rather, we add a number of extension methods to make using the `HttpClient` more fluent.

See the sample project for a working demonstration.