### PR TITLE
Fix constructor for applying default value given

### DIFF
--- a/src/Grapevine/GlobalResponseHeader.cs
+++ b/src/Grapevine/GlobalResponseHeader.cs
@@ -13,7 +13,7 @@ namespace Grapevine
         public GlobalResponseHeader(string name, string defaultValue, bool suppress = false)
         {
             Name = name;
-            Value = Value;
+            Value = defaultValue;
             Suppress = suppress;
         }
     }


### PR DESCRIPTION
The problem is that the default value given is not being
applied, there is a typo probably and the initialization is
not correct. 

In the current version you need to do something like this:
```
GlobalResponseHeader contentTypeHeader = new GlobalResponseHeader("Content-Type", "application/json");
server.GlobalResponseHeaders.Add(contentTypeHeader);
server.GlobalResponseHeaders[server.GlobalResponseHeaders.IndexOf(contentTypeHeader)].Value = "application/json";
```