### PR TITLE
Reduces Extension Aliases and Changes Cookies Base

### DIFF
--- a/src/Grapevine/Client/Cookies.cs
+++ b/src/Grapevine/Client/Cookies.cs
@@ -1,5 +1,5 @@
 using System;
-using System.Collections.Specialized;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Grapevine.Client
@@ -7,42 +7,34 @@ namespace Grapevine.Client
     /// <summary>
     /// Provides access the cookies for the request
     /// </summary>
-    public class Cookies : NameValueCollection
+    public class Cookies : Dictionary<string, string>
     {
         private static char[] _invalidNameChars = @"()<>@,;:\/[]?={}""".ToCharArray();
-
         private static char[] _invalidValueChars = @",;\""".ToCharArray();
 
-        public override void Add(string name, string value)
+        public new string this[string key]
         {
-            ValidateName(name);
-            ValidateValue(value);
-            base.Add(name, value);
-        }
-
-        public new void Add(NameValueCollection c)
-        {
-            c.AllKeys.ToList().ForEach(k =>
+            get { return base[key]; }
+            set
             {
-                ValidateName(k);
-                ValidateValue(c[k]);
-            });
-
-            base.Add(c);
+                ValidateName(key);
+                ValidateValue(value);
+                base[key] = value;
+            }
         }
 
-        public override void Set(string name, string value)
+        public new void Add(string key, string value)
         {
-            ValidateName(name);
-            ValidateValue(value);
-            base.Set(name, value);
+                ValidateName(key);
+                ValidateValue(value);
+                base.Add(key, value);
         }
 
         public override string ToString()
         {
             return Count <= 0
                 ? string.Empty
-                : string.Join("; ", (from key in AllKeys let value = Get(key) select Uri.EscapeDataString(key) + "=" + Uri.EscapeDataString(value)).ToArray());
+                : string.Join("; ", (from key in Keys let value = base[key] select $"{key}={Uri.EscapeUriString(value)}").ToArray());
         }
 
         private void ValidateName(string name)

--- a/src/Grapevine/Client/RestRequestBuilder.cs
+++ b/src/Grapevine/Client/RestRequestBuilder.cs
@@ -37,7 +37,7 @@ namespace Grapevine.Client
             _client = client;
         }
 
-        public async Task<HttpResponseMessage> SendAsync(HttpMethod method, CancellationToken token)
+        public async Task<HttpResponseMessage> SendAsync(HttpMethod method, CancellationToken? token = null)
         {
             Request.Method = method;
 
@@ -53,7 +53,8 @@ namespace Grapevine.Client
                 ? new Uri($"{_client.BaseAddress.ToString().TrimEnd('/')}/{Route.TrimStart('/')}{QueryParams.ToString()}")
                 : new Uri($"{Route}{QueryParams.ToString()}");
 
-            return await _client.SendAsync(Request, HttpCompletionOption.ResponseContentRead, token).ConfigureAwait(false);
+            token = token ?? CancellationToken.None;
+            return await _client.SendAsync(Request, HttpCompletionOption.ResponseContentRead, token.Value).ConfigureAwait(false);
         }
     }
 }

--- a/src/Grapevine/Client/RestRequestBuilderExtensions.cs
+++ b/src/Grapevine/Client/RestRequestBuilderExtensions.cs
@@ -51,13 +51,13 @@ namespace Grapevine.Client
 
         public static RestRequestBuilder WithCookie(this RestRequestBuilder builder, string key, string value)
         {
-            builder.Cookies[key] = value;
+            builder.Cookies.Add(key, value);
             return builder;
         }
 
         public static RestRequestBuilder WithCookies(this RestRequestBuilder builder, IEnumerable<KeyValuePair<string, string>> cookies)
         {
-            foreach (var cookie in cookies) builder.Cookies[cookie.Key] = cookie.Value;
+            foreach (var cookie in cookies) builder.Cookies.Add(cookie.Key, cookie.Value);
             return builder;
         }
 
@@ -113,47 +113,22 @@ namespace Grapevine.Client
     /// </summary>
     public static partial class RestRequestBuilderExtensions
     {
-        public static async Task<HttpResponseMessage> DeleteAsync(this RestRequestBuilder builder)
-        {
-            return await builder.DeleteAsync(CancellationToken.None).ConfigureAwait(false);
-        }
-
-        public static async Task<HttpResponseMessage> DeleteAsync(this RestRequestBuilder builder, CancellationToken token)
+        public static async Task<HttpResponseMessage> DeleteAsync(this RestRequestBuilder builder, CancellationToken? token = null)
         {
             return await builder.SendAsync("Delete", token).ConfigureAwait(false);
         }
 
-        public static async Task<HttpResponseMessage> GetAsync(this RestRequestBuilder builder)
-        {
-            return await builder.GetAsync(CancellationToken.None).ConfigureAwait(false);
-        }
-
-        public static async Task<HttpResponseMessage> GetAsync(this RestRequestBuilder builder, CancellationToken token)
+        public static async Task<HttpResponseMessage> GetAsync(this RestRequestBuilder builder, CancellationToken? token = null)
         {
             return await builder.SendAsync("Get", token).ConfigureAwait(false);
         }
 
-        public static async Task<HttpResponseMessage> SendAsync(this RestRequestBuilder builder, HttpMethod method)
-        {
-            return await builder.SendAsync(method, CancellationToken.None);
-        }
-
-        public static async Task<HttpResponseMessage> PostAsync(this RestRequestBuilder builder)
-        {
-            return await builder.PostAsync(CancellationToken.None).ConfigureAwait(false);
-        }
-
-        public static async Task<HttpResponseMessage> PostAsync(this RestRequestBuilder builder, CancellationToken token)
+        public static async Task<HttpResponseMessage> PostAsync(this RestRequestBuilder builder, CancellationToken? token = null)
         {
             return await builder.SendAsync("Post", token).ConfigureAwait(false);
         }
 
-        public static async Task<HttpResponseMessage> PutAsync(this RestRequestBuilder builder)
-        {
-            return await builder.PutAsync(CancellationToken.None).ConfigureAwait(false);
-        }
-
-        public static async Task<HttpResponseMessage> PutAsync(this RestRequestBuilder builder, CancellationToken token)
+        public static async Task<HttpResponseMessage> PutAsync(this RestRequestBuilder builder, CancellationToken? token = null)
         {
             return await builder.SendAsync("Put", token).ConfigureAwait(false);
         }


### PR DESCRIPTION
- Reduces the number of extension method aliases for `RestRequestBuilder.SendAsync`
- Changes base class of `Grapevine.Client.Cookies` from `NameValueCollection` to `Dictionary<string, string>`