### PR TITLE
Changes from writing documentation

### DIFF
--- a/src/Grapevine/IRestServer.cs
+++ b/src/Grapevine/IRestServer.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 
@@ -118,10 +119,13 @@ namespace Grapevine
         /// <summary>
         /// Starts the server and blocks the calling thread until the server stops listening
         /// </summary>
-        public static void Run(this IRestServer server)
+        /// <param name="server"></param>
+        /// <param name="pollingInterval">Number of seconds to wait between polling IRestServer.IsListening</param>
+        public static void Run(this IRestServer server, int pollingInterval = 1)
         {
             server.Start();
-            while (server.IsListening) { }
+            var sleep = pollingInterval * 1000;
+            while (server.IsListening) { Thread.Sleep(sleep); }
         }
     }
 }

--- a/src/Grapevine/IRouteScanner.cs
+++ b/src/Grapevine/IRouteScanner.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -12,6 +13,12 @@ namespace Grapevine
         /// </summary>
         /// <value></value>
         string BasePath { get; set; }
+
+        /// <summary>
+        /// List of assemblies to be ignored when scanning for routes
+        /// </summary>
+        /// <value></value>
+        IList<string> IgnoredAssemblies { get; }
 
         /// <summary>
         /// Register implementations for types scanned that contained route methods
@@ -77,6 +84,48 @@ namespace Grapevine
         public static IList<IRoute> Scan<T>(this IRouteScanner scanner, string basePath = null)
         {
             return scanner.Scan(typeof(T), basePath);
+        }
+
+        /// <summary>
+        /// Add an assembly to be ignored when scanning all assemblies for routes
+        /// </summary>
+        /// <param name="assembly"></param>
+        public static void AddIgnoredAssembly(this IRouteScanner scanner, Assembly assembly)
+        {
+            scanner.IgnoredAssemblies.Add(assembly.GetName().Name);
+        }
+
+        /// <summary>
+        /// Add a list of assemblies to be ignored when scanning all assemblies for routes
+        /// </summary>
+        /// <param name="assemblies"></param>
+        public static void AddIgnoredAssemblies(this IRouteScanner scanner, Assembly[] assemblies)
+        {
+            foreach (var assembly in assemblies) scanner.IgnoredAssemblies.Add(assembly.GetName().Name);
+        }
+
+        /// <summary>
+        /// Add an assembly to be ignored when scanning all assemblies for routes
+        /// </summary>
+        /// <param name="assemblyName"></param>
+        public static void AddIgnoredAssembly(this IRouteScanner scanner, string assemblyName)
+        {
+            scanner.IgnoredAssemblies.Add(assemblyName);
+        }
+
+        /// <summary>
+        /// Add a list of assemblies to be ignored when scanning all assemblies for routes
+        /// </summary>
+        /// <param name="assemblyNames"></param>
+        public static void AddIgnoredAssemblies(this IRouteScanner scanner, string[] assemblyNames)
+        {
+            foreach (var assemblyName in assemblyNames) scanner.IgnoredAssemblies.Add(assemblyName);
+        }
+
+        public static void IgnoreAssemblyContainingType<T>(this IRouteScanner scanner)
+        {
+            Assembly assembly = Assembly.GetAssembly(typeof(T));
+            scanner.IgnoredAssemblies.Add(assembly.GetName().Name);
         }
     }
 }

--- a/src/Grapevine/RouteScanner.cs
+++ b/src/Grapevine/RouteScanner.cs
@@ -18,7 +18,7 @@ namespace Grapevine
         /// Returns an enumeration of assemblies not on the IgnoredAssemblies list
         /// </summary>
         /// <value></value>
-        public static IEnumerable<Assembly> Assemblies
+        public IEnumerable<Assembly> Assemblies
         {
             get
             {
@@ -35,7 +35,7 @@ namespace Grapevine
         /// List of assembly names to be ignored when scanning all assemblies
         /// </summary>
         /// <value></value>
-        public static readonly List<string> IgnoredAssemblies = new List<string>
+        public IList<string> IgnoredAssemblies { get; } = new List<string>
         {
             "vshost",
             "xunit",
@@ -45,42 +45,6 @@ namespace Grapevine
             "netstandard",
             "TestPlatform",
         };
-
-        /// <summary>
-        /// Add an assembly to be ignored when scanning all assemblies for routes
-        /// </summary>
-        /// <param name="assembly"></param>
-        public static void AddIgnoredAssembly(Assembly assembly)
-        {
-            AddIgnoredAssembly(assembly.GetName().Name);
-        }
-
-        /// <summary>
-        /// Add a list of assemblies to be ignored when scanning all assemblies for routes
-        /// </summary>
-        /// <param name="assemblies"></param>
-        public static void AddIgnoredAssemblies(Assembly[] assemblies)
-        {
-            IgnoredAssemblies.AddRange(assemblies.Select(a => a.GetName().Name));
-        }
-
-        /// <summary>
-        /// Add an assembly to be ignored when scanning all assemblies for routes
-        /// </summary>
-        /// <param name="assemblyName"></param>
-        public static void AddIgnoredAssembly(string assemblyName)
-        {
-            IgnoredAssemblies.Add(assemblyName);
-        }
-
-        /// <summary>
-        /// Add a list of assemblies to be ignored when scanning all assemblies for routes
-        /// </summary>
-        /// <param name="assemblyNames"></param>
-        public static void AddIgnoredAssemblies(string[] assemblyNames)
-        {
-            IgnoredAssemblies.AddRange(assemblyNames);
-        }
 
         public abstract IList<IRoute> Scan(string basePath = null);
         public abstract IList<IRoute> Scan(Assembly assembly, string basePath = null);

--- a/src/Samples/Program.cs
+++ b/src/Samples/Program.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -38,7 +38,8 @@ namespace Samples
                 };
 
                 // server.Router.GetServiceProvider().GetRequiredService<LocalClient>().RunInteractiveShell(server);
-                server.Run();
+                server.Start();
+                Console.ReadLine();
             }
         }
 

--- a/src/Samples/Startup.cs
+++ b/src/Samples/Startup.cs
@@ -11,13 +11,13 @@ namespace Samples
 {
     public class Startup
     {
-        private IConfiguration _configuration;
+        public IConfiguration Configuration { get; private set; }
 
         private string _serverPort = PortFinder.FindNextLocalOpenPort(1234);
 
         public Startup(IConfiguration configuration)
         {
-            _configuration = configuration;
+            Configuration = configuration;
         }
 
         public void ConfigureServices(IServiceCollection services)
@@ -25,7 +25,7 @@ namespace Samples
             services.AddLogging(loggingBuilder =>
             {
                 loggingBuilder.ClearProviders();
-                loggingBuilder.AddNLog(_configuration);
+                loggingBuilder.AddNLog(Configuration);
             });
 
             services.AddHttpClient<GitHubClient>(c =>


### PR DESCRIPTION
- Changes how `IRestServer.Run` keeps the thread blocked
- Adds `IgnoredAssemblies` to `IRouteScanner` interface (no longer static)
- Adds extension methods to `IRouteScanner` to ignore assembly by containing type
- Router now checks cancellation token during routing process
- Cleanup to Sample project