### PR TITLE
Improves performance of IRestServer.Run

### DIFF
--- a/src/Grapevine/IRestServer.cs
+++ b/src/Grapevine/IRestServer.cs
@@ -115,17 +115,5 @@ namespace Grapevine
         {
             foreach (var header in server.GlobalResponseHeaders.Where(g => !g.Suppress)) headers.Add(header.Name, header.Value);
         }
-
-        /// <summary>
-        /// Starts the server and blocks the calling thread until the server stops listening
-        /// </summary>
-        /// <param name="server"></param>
-        /// <param name="pollingInterval">Number of seconds to wait between polling IRestServer.IsListening</param>
-        public static void Run(this IRestServer server, int pollingInterval = 1)
-        {
-            server.Start();
-            var sleep = pollingInterval * 1000;
-            while (server.IsListening) { Thread.Sleep(sleep); }
-        }
     }
 }

--- a/src/Samples/Program.cs
+++ b/src/Samples/Program.cs
@@ -37,9 +37,7 @@ namespace Samples
                     OpenBrowser(s.Prefixes.First());
                 };
 
-                // server.Router.GetServiceProvider().GetRequiredService<LocalClient>().RunInteractiveShell(server);
-                server.Start();
-                Console.ReadLine();
+                server.Run();
             }
         }
 


### PR DESCRIPTION
Changes the `IRestServer.Run()` method to use a `ManualResetToken`, rather than polling for `IRestServer.IsListenting` every _n_ seconds or running a CPU intensive `while (true) { }` loop.