### PR TITLE
Extension Methods Fix

### DIFF
--- a/src/Grapevine/Client/HttpResponseMessageExtensions.cs
+++ b/src/Grapevine/Client/HttpResponseMessageExtensions.cs
@@ -9,7 +9,7 @@ namespace Grapevine.Client
     {
         public static async Task<string> GetResponseStringAsync(this HttpResponseMessage responseMessage)
         {
-            return (responseMessage.IsSuccessStatusCode)
+            return (responseMessage.Content != null)
                 ? await responseMessage.Content.ReadAsStringAsync().ConfigureAwait(false)
                 : responseMessage.StatusCode.ToString();
         }
@@ -22,7 +22,7 @@ namespace Grapevine.Client
 
         public static async Task<Stream> GetResponseStreamAsync(this HttpResponseMessage responseMessage)
         {
-            return (responseMessage.IsSuccessStatusCode)
+            return (responseMessage.Content != null)
                 ? await responseMessage.Content.ReadAsStreamAsync().ConfigureAwait(false)
                 : new MemoryStream(Encoding.UTF8.GetBytes(responseMessage.StatusCode.ToString()));
         }
@@ -35,7 +35,7 @@ namespace Grapevine.Client
 
         public static async Task<byte[]> GetResponseBytesAsync(this HttpResponseMessage responseMessage)
         {
-            return (responseMessage.IsSuccessStatusCode)
+            return (responseMessage.Content != null)
                 ? await responseMessage.Content.ReadAsByteArrayAsync().ConfigureAwait(false)
                 : Encoding.UTF8.GetBytes(responseMessage.StatusCode.ToString());
         }


### PR DESCRIPTION
Extension methods on `HttpResponseMessage` would attempt to read content from the `Content` property based on whether or not the status code on the response indicated a success. This was a failure for two reasons:

1. A successful response might not contain any content
2. A failure response might contain content about the failure

The methods have been refactored to key off of whether the `Content` property is not null.