### PR TITLE
Add net461 TargetFramework

### DIFF
--- a/src/Grapeseed/Grapeseed.csproj
+++ b/src/Grapeseed/Grapeseed.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.0;netstandard2.1;net5.0</TargetFrameworks>
     <PackageId>Grapeseed</PackageId>
     <PackageVersion>$(Version)</PackageVersion>
     <Authors>Scott Offen</Authors>
@@ -28,6 +28,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$(TargetFramework) == 'net461'">
+    <Reference Include="System.Net.Http" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Grapevine/Client/Cookies.cs
+++ b/src/Grapevine/Client/Cookies.cs
@@ -29,7 +29,7 @@ namespace Grapevine.Client
             base.Add(ValidateName(key), ValidateValue(value.ToString()));
         }
 
-#if !NETSTANDARD2_0
+#if !(NETSTANDARD2_0 || NETFRAMEWORK)
 
         public new bool TryAdd(string key, string value)
         {

--- a/src/Grapevine/Grapevine.csproj
+++ b/src/Grapevine/Grapevine.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.0;netstandard2.1;net5.0</TargetFrameworks>
     <PackageId>Grapevine</PackageId>
     <PackageVersion>$(Version)</PackageVersion>
     <Authors>Scott Offen</Authors>
@@ -32,6 +32,10 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
+  </ItemGroup>
+  
+  <ItemGroup Condition="$(TargetFramework) == 'net461'">
+    <Reference Include="System.Net.Http" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This adds net461 as a target so that projects using mono 4.6 can use Grapevine 5.
All dependent packages are available for 461, only System.Net.Http needed to be referenced.