### PR TITLE
5.0.0 rc.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@ Grapevine is available on [NuGet.org](https://www.nuget.org/packages/Grapevine/)
 
 Powershell:
 ```powershell
-Install-Package Grapevine -Version 5.0.0-rc.5
+Install-Package Grapevine -Version 5.0.0-rc.8
 ```
 
 .NET CLI
 ```cmd
-> dotnet add package Grapevine --version 5.0.0-rc.5
+> dotnet add package Grapevine --version 5.0.0-rc.8
 ```
 
 ## Usage

--- a/src/Grapeseed/GlobalResponseHeaders.cs
+++ b/src/Grapeseed/GlobalResponseHeaders.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 
 namespace Grapevine
 {
-    public class GlobalResponseHeader
+    public class GlobalResponseHeaders
     {
         public string Name { get; set; }
 
@@ -10,7 +10,7 @@ namespace Grapevine
 
         public bool Suppress { get; set; }
 
-        public GlobalResponseHeader(string name, string defaultValue, bool suppress = false)
+        public GlobalResponseHeaders(string name, string defaultValue, bool suppress = false)
         {
             Name = name;
             Value = defaultValue;
@@ -20,9 +20,9 @@ namespace Grapevine
 
     public static class GlobalResponseHeaderExtensions
     {
-        public static void Add(this IList<GlobalResponseHeader> headers, string key, string value)
+        public static void Add(this IList<GlobalResponseHeaders> headers, string key, string value)
         {
-            headers.Add(new GlobalResponseHeader(key, value));
+            headers.Add(new GlobalResponseHeaders(key, value));
         }
     }
 }

--- a/src/Grapeseed/Grapeseed.csproj
+++ b/src/Grapeseed/Grapeseed.csproj
@@ -11,7 +11,7 @@
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <AssemblyVersion>$(Version)</AssemblyVersion>
     <FileVersion>$(Version)</FileVersion>
-    <Version>5.0.0-rc.7</Version>
+    <Version>5.0.0-rc.8</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <RepositoryUrl>https://github.com/scottoffen/grapevine</RepositoryUrl>

--- a/src/Grapeseed/IRestServer.cs
+++ b/src/Grapeseed/IRestServer.cs
@@ -31,7 +31,7 @@ namespace Grapevine
         /// Gets or sets a list of header keys and values that should be applied to all outbound responses.
         /// </summary>
         /// <value></value>
-        IList<GlobalResponseHeader> GlobalResponseHeaders { get; set; }
+        IList<GlobalResponseHeaders> GlobalResponseHeaders { get; set; }
 
         /// <summary>
         /// Gets a value that indicates whether the server is currently listening.

--- a/src/Grapevine/Client/HttpClientExtensions.cs
+++ b/src/Grapevine/Client/HttpClientExtensions.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Net.Http;
 
 namespace Grapevine.Client

--- a/src/Grapevine/Grapevine.csproj
+++ b/src/Grapevine/Grapevine.csproj
@@ -12,7 +12,7 @@
     <PackageTags>rest http api web router client server express json xml embedded</PackageTags>
     <AssemblyVersion>$(Version)</AssemblyVersion>
     <FileVersion>$(Version)</FileVersion>
-    <Version>5.0.0-rc.7</Version>
+    <Version>5.0.0-rc.8</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <RepositoryUrl>https://github.com/scottoffen/grapevine</RepositoryUrl>

--- a/src/Grapevine/Grapevine.csproj
+++ b/src/Grapevine/Grapevine.csproj
@@ -23,7 +23,6 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
-    <NoWarn>CS0067</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Grapevine/RestServer.cs
+++ b/src/Grapevine/RestServer.cs
@@ -10,7 +10,7 @@ namespace Grapevine
     {
         public IList<IContentFolder> ContentFolders { get; } = new List<IContentFolder>();
 
-        public IList<GlobalResponseHeader> GlobalResponseHeaders { get; set; } = new List<GlobalResponseHeader>();
+        public IList<GlobalResponseHeaders> GlobalResponseHeaders { get; set; } = new List<GlobalResponseHeaders>();
 
         public virtual bool IsListening { get; }
 


### PR DESCRIPTION
- Renames `GlobalResponseHeader` to `GlobalResponseHeaders`
- Updates version number to 5.0.0-rc.8
- Fixes #57 Stack overflow crash when unknown route received