### PR TITLE
2022-02 Updates

### DIFF
--- a/src/Grapeseed/Grapeseed.csproj
+++ b/src/Grapeseed/Grapeseed.csproj
@@ -11,7 +11,7 @@
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <AssemblyVersion>$(Version)</AssemblyVersion>
     <FileVersion>$(Version)</FileVersion>
-    <Version>5.0.0-rc.8</Version>
+    <Version>5.0.0-rc.9</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <RepositoryUrl>https://github.com/scottoffen/grapevine</RepositoryUrl>

--- a/src/Grapeseed/RouteScanner.cs
+++ b/src/Grapeseed/RouteScanner.cs
@@ -23,7 +23,7 @@ namespace Grapevine
             get
             {
                 foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies()
-                    .Where(a => a.GetName().Name != "Grapevine" && !a.GetName().Name.StartsWith(IgnoredAssemblies.ToArray()))
+                    .Where(a => a.GetName().Name != "Grapevine" && a.GetName().Name != "Grapeseed" && !a.GetName().Name.StartsWith(IgnoredAssemblies.ToArray()))
 #if NETSTANDARD
                     .Where(a => !a.GlobalAssemblyCache)
 #endif
@@ -80,7 +80,7 @@ namespace Grapevine
                 }
                 catch (ReflectionTypeLoadException ex)
                 {
-                    var message = $"Exception occured when scanning for routes";
+                    var message = $"Exception occurred when scanning for routes";
                     foreach (var loaderEx in ex.LoaderExceptions)
                     {
                         Logger.LogDebug(loaderEx, message);
@@ -108,7 +108,7 @@ namespace Grapevine
             }
             catch (ReflectionTypeLoadException ex)
             {
-                var message = $"Exception occured when scanning assembly {name} for routes";
+                var message = $"Exception occurred when scanning assembly {name} for routes";
                 foreach (var loaderEx in ex.LoaderExceptions)
                     Logger.LogDebug(loaderEx, message);
             }
@@ -201,7 +201,7 @@ namespace Grapevine
         }
 
         /// <summary>
-        /// Returns an enumeration of MethodInfo in the specified type that have the RestRoute attribute, order by appearence in the type
+        /// Returns an enumeration of MethodInfo in the specified type that have the RestRoute attribute, order by appearance in the type
         /// </summary>
         /// <param name="type"></param>
         /// <returns></returns>

--- a/src/Grapeseed/Router.cs
+++ b/src/Grapeseed/Router.cs
@@ -158,7 +158,7 @@ namespace Grapevine
             }
             catch (Exception e)
             {
-                Logger.LogError(e, $"{context.Id}: An exception occured while routing request {context.Request.Name}");
+                Logger.LogError(e, $"{context.Id}: An exception occurred while routing request {context.Request.Name}");
                 await HandleErrorAsync(context, e);
             }
         }

--- a/src/Grapevine/Grapevine.csproj
+++ b/src/Grapevine/Grapevine.csproj
@@ -12,7 +12,7 @@
     <PackageTags>rest http api web router client server express json xml embedded</PackageTags>
     <AssemblyVersion>$(Version)</AssemblyVersion>
     <FileVersion>$(Version)</FileVersion>
-    <Version>5.0.0-rc.8</Version>
+    <Version>5.0.0-rc.9</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <RepositoryUrl>https://github.com/scottoffen/grapevine</RepositoryUrl>

--- a/src/Grapevine/HttpRequest.cs
+++ b/src/Grapevine/HttpRequest.cs
@@ -52,6 +52,7 @@ namespace Grapevine
         public string UserHostname => Advanced.UserHostName;
 
         public string[] UserLanguages => Advanced.UserLanguages;
+
         public HttpRequest(HttpListenerRequest request)
         {
             Advanced = request;

--- a/src/Grapevine/Middleware/ContentFolders.cs
+++ b/src/Grapevine/Middleware/ContentFolders.cs
@@ -5,7 +5,7 @@ namespace Grapevine.Middleware
 {
     public static class ContentFolders
     {
-        public async static Task SendFileIfExistsAsnyc(IHttpContext context, IRestServer server)
+        public async static Task SendFileIfExistsAsync(IHttpContext context, IRestServer server)
         {
             // If a matching file is found, the request will be responded to.
             if (context.Request.HttpMethod == HttpMethod.Get)

--- a/src/Grapevine/MiddlewareExtensions.cs
+++ b/src/Grapevine/MiddlewareExtensions.cs
@@ -46,7 +46,8 @@ namespace Grapevine
 
         public static IRestServer UseContentFolders(this IRestServer server)
         {
-            server.OnRequestAsync += ContentFolders.SendFileIfExistsAsnyc;
+            server.OnRequestAsync -= ContentFolders.SendFileIfExistsAsync;
+            server.OnRequestAsync += ContentFolders.SendFileIfExistsAsync;
             return server;
         }
 

--- a/src/Grapevine/RestServer.cs
+++ b/src/Grapevine/RestServer.cs
@@ -173,7 +173,7 @@ namespace Grapevine
             {
                 exceptionWasThrown = true;
 
-                Logger.LogCritical(e, "An unexpected error occured when attempting to start the server");
+                Logger.LogCritical(e, "An unexpected error occurred when attempting to start the server");
                 throw;
             }
             finally
@@ -185,6 +185,12 @@ namespace Grapevine
                 }
 
                 IsStarting = false;
+
+                if (this.ContentFolders.Count > 0)
+                {
+                    Logger.LogInformation("Grapevine has detected that content folders have been added");
+                    Logger.LogInformation("Enable serving content from content folders with: server.UseContentFolders()");
+                }
             }
         }
 
@@ -243,7 +249,7 @@ namespace Grapevine
                 }
                 catch (Exception e)
                 {
-                    Logger.LogDebug(e, "An unexpected error occured while listening for incoming requests.");
+                    Logger.LogDebug(e, "An unexpected error occurred while listening for incoming requests.");
                 }
             }
         }
@@ -270,7 +276,7 @@ namespace Grapevine
             }
             catch (Exception e)
             {
-                Logger.LogError(e, $"{context.Id} An exception occured while routing request {context.Request.Name}");
+                Logger.LogError(e, $"{context.Id} An exception occurred while routing request {context.Request.Name}");
             }
 
             // 4. Optionally route request

--- a/src/Samples/Program.cs
+++ b/src/Samples/Program.cs
@@ -28,7 +28,7 @@ namespace Samples
                     var sb = new StringBuilder(Environment.NewLine);
                     sb.Append($"********************************************************************************{Environment.NewLine}");
                     sb.Append($"* Server listening on {string.Join(", ", server.Prefixes)}{Environment.NewLine}");
-                    sb.Append($"* Stop server by going to {server.Prefixes.First()}/api/stop{Environment.NewLine}");
+                    sb.Append($"* Stop server by going to {server.Prefixes.First()}api/stop{Environment.NewLine}");
                     sb.Append($"********************************************************************************{Environment.NewLine}");
                     s.Logger.LogDebug(sb.ToString());
 

--- a/src/Samples/Startup.cs
+++ b/src/Samples/Startup.cs
@@ -25,7 +25,7 @@ namespace Samples
             services.AddLogging(loggingBuilder =>
             {
                 loggingBuilder.ClearProviders();
-                loggingBuilder.AddNLog(Configuration);
+                loggingBuilder.AddNLog(new NLogLoggingConfiguration(Configuration.GetSection("NLog")));
             });
 
             services.AddHttpClient<GitHubClient>(c =>

--- a/src/Samples/appsettings.json
+++ b/src/Samples/appsettings.json
@@ -1,0 +1,32 @@
+{
+    "NLog":{
+        "internalLogLevel":"Info",
+        "internalLogFile":"c:\\temp\\internal-nlog.txt",
+        "extensions": [
+          { "assembly": "NLog.Extensions.Logging" }
+        ],
+        "targets":{
+            "log-file":{
+                "type":"File",
+                "fileName":"c:\\temp\\grapevine-sample-${shortdate}.log",
+                "layout":"${longdate}|${uppercase:${level}}|${logger}|${message} ${exception:format=tostring}|${all-event-properties}"
+            },
+            "log-console":{
+                "type":"Console",
+                "layout":"${longdate}|${uppercase:${level}}|${logger}|${message} ${exception:format=tostring}|${all-event-properties}"
+            }
+        },
+        "rules":[
+            {
+                "logger":"*",
+                "minLevel":"Trace",
+                "writeTo":"log-file"
+            },
+            {
+                "logger":"*",
+                "minLevel":"Info",
+                "writeTo":"log-console"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
- RouteScanner now ignores scanning Grapeseed
- Reminder added at start up to information log when content folders have been added to also call server.UseContentFolders() middleware.
- Adds working NLog configuration to sample project
- Numerous typos and spacing issues fixed
- Fixes #97 