### PR TITLE
Add features for parsing form data

### DIFF
--- a/src/Grapeseed/IHttpRequest.cs
+++ b/src/Grapeseed/IHttpRequest.cs
@@ -53,6 +53,11 @@ namespace Grapevine
         Stream InputStream { get; }
 
         /// <summary>
+        /// Gets the multipart boundary, returns empty string if not available
+        /// </summary>
+        string MultipartBoundary { get; }
+
+        /// <summary>
         /// Gets a representation of the HttpMethod and Endpoint of the request
         /// </summary>
         string Name { get; }

--- a/src/Grapevine/HttpRequest.cs
+++ b/src/Grapevine/HttpRequest.cs
@@ -29,6 +29,8 @@ namespace Grapevine
 
         public Stream InputStream => Advanced.InputStream;
 
+        public string MultipartBoundary { get; }
+
         public string Name => $"{HttpMethod} {Endpoint}";
 
         public string Endpoint { get; protected set; }
@@ -58,6 +60,7 @@ namespace Grapevine
             Advanced = request;
             Endpoint = request.Url.AbsolutePath.TrimEnd('/');
             HostPrefix = request.Url.GetComponents(UriComponents.SchemeAndServer, UriFormat.Unescaped);
+            MultipartBoundary = this.GetMultipartBoundary();
         }
     }
 }

--- a/src/Grapevine/HttpRequestExtensions.cs
+++ b/src/Grapevine/HttpRequestExtensions.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace Grapevine
+{
+    public static class HttpRequestExtensions
+    {
+        private static readonly string _multipartContentType = "multipart/form-data; boundary=";
+        private static readonly int _startIndex = _multipartContentType.Length;
+
+        internal static string GetMultipartBoundary(this IHttpRequest request)
+        {
+            return (string.IsNullOrWhiteSpace(request.ContentType) || !request.ContentType.StartsWith(_multipartContentType))
+                ? string.Empty
+                : request.ContentType.Substring(_startIndex);
+        }
+
+        public static async Task<IDictionary<string, string>> ParseFormUrlEncodedData(this IHttpRequest request)
+        {
+            var data = new Dictionary<string, string>();
+
+            using (var reader = new StreamReader(request.InputStream, request.ContentEncoding))
+            {
+                var payload = await reader.ReadToEndAsync();
+
+                foreach (var kvp in payload.Split('&'))
+                {
+                    var pair = kvp.Split('=');
+                    var key = pair[0];
+                    var value = pair[1];
+
+                    var decoded = string.Empty;
+                    while((decoded = Uri.UnescapeDataString(value)) != value)
+                    {
+                        value = decoded;
+                    }
+
+                    data.Add(key, value);
+                }
+            }
+
+            return data;
+        }
+    }
+}

--- a/src/Grapevine/Middleware/FormUrlEncodedData.cs
+++ b/src/Grapevine/Middleware/FormUrlEncodedData.cs
@@ -1,0 +1,13 @@
+using System.Threading.Tasks;
+
+namespace Grapevine.Middleware
+{
+    public static class FormUrlEncodedData
+    {
+        public async static Task Parse(IHttpContext context, IRestServer server)
+        {
+            if (context.Request.ContentType != "application/x-www-form-urlencoded") return;
+            context.Locals.TryAdd("FormData", await context.Request.ParseFormUrlEncodedData());
+        }
+    }
+}

--- a/src/Grapevine/MiddlewareExtensions.cs
+++ b/src/Grapevine/MiddlewareExtensions.cs
@@ -44,6 +44,13 @@ namespace Grapevine
             server.AfterStopping -= onStop;
         }
 
+        public static IRestServer AutoParseFormUrlEncodedData(this IRestServer server)
+        {
+            server.OnRequestAsync -= FormUrlEncodedData.Parse;
+            server.OnRequestAsync += FormUrlEncodedData.Parse;
+            return server;
+        }
+
         public static IRestServer UseContentFolders(this IRestServer server)
         {
             server.OnRequestAsync -= ContentFolders.SendFileIfExistsAsync;

--- a/src/Samples/Resources/FormDataResource.cs
+++ b/src/Samples/Resources/FormDataResource.cs
@@ -1,0 +1,36 @@
+using System.Threading.Tasks;
+using Grapevine;
+using HttpMultipartParser;
+using Microsoft.Extensions.Logging;
+
+namespace Samples.Resources
+{
+    [RestResource(BasePath = "form")]
+    public class FormDataResource
+    {
+        private readonly ILogger<FormDataResource> _logger;
+
+        public FormDataResource(ILogger<FormDataResource> logger)
+        {
+            _logger = logger;
+        }
+
+        [RestRoute("Post", "/submit/data", Name = "Upload form data", Description = "This demonstrates how to parse application/www-form-urlencoded data.")]
+        [Header("Content-Type", "application/x-www-form-urlencoded")]
+        public async Task ParseUrlEncodedFormData(IHttpContext context)
+        {
+            // set a breakpoint here to see the auto-parsed data
+            await context.Response.SendResponseAsync(HttpStatusCode.Ok);
+        }
+
+        [RestRoute("Post", "/submit/data", Name = "Upload form data", Description = "This demonstrates how to parse simple multipart/form-data.")]
+        [Header("Content-Type", "multipart/form-data")]
+        public async Task ParseMultipartFormData(IHttpContext context)
+        {
+            // https://github.com/Http-Multipart-Data-Parser/Http-Multipart-Data-Parser
+            var content = await MultipartFormDataParser.ParseAsync(context.Request.InputStream, context.Request.MultipartBoundary, context.Request.ContentEncoding);
+            var name = $"{content.GetParameterValue("FirstName")} {content.GetParameterValue("LastName")} : {content.Files.Count}";
+            await context.Response.SendResponseAsync(name);
+        }
+    }
+}

--- a/src/Samples/Samples.csproj
+++ b/src/Samples/Samples.csproj
@@ -5,6 +5,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="HttpMultipartParser" Version="5.0.1" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
     <PackageReference Include="NLog" Version="4.7.6" />

--- a/src/Samples/Startup.cs
+++ b/src/Samples/Startup.cs
@@ -48,6 +48,9 @@ namespace Samples
 
             server.Prefixes.Add($"http://localhost:{_serverPort}/");
 
+            /* Configure server to auto parse application/x-www-for-urlencoded data*/
+            server.AutoParseFormUrlEncodedData();
+
             /* Configure Router Options (if supported by your router implementation) */
             server.Router.Options.SendExceptionMessages = true;
         }


### PR DESCRIPTION
- Added middleware `server.AutoParseFormUrlEncodedData()`. Using this will automatically parse your url-encoded form data and store it in `context.Locals` as a `IDictionary<string,string>` under the key `FormData`. _Does not work with multipart form data!_

- Added extension method `IHttpRequest.ParseFormUrlEncodedData()` which will return a the url-encoded form data as a `IDictionary<string,string>`. Because the input stream can only be read once, this method will only return data the first time it is called. **It is recommended to use the aforementioned middleware instead of this method.**

- Added `IHttpRequest.MultipartBoundary`, which will contain the multipart boundary for easy access to parse multipart data.

- Added sample resources for parsing multipart data using [HttpMultipartParser](https://www.nuget.org/packages/HttpMultipartParser/) (see on [GitHub](https://github.com/Http-Multipart-Data-Parser/Http-Multipart-Data-Parser))