### PR TITLE
Change hardcoded directory separator character

### DIFF
--- a/src/Grapeseed/ContentFolder.cs
+++ b/src/Grapeseed/ContentFolder.cs
@@ -40,8 +40,8 @@ namespace Grapevine
 
             DirectoryMapping[CreateDirectoryListingKey(fullPath)] = fullPath;
 
-            if (fullPath.EndsWith($"\\{IndexFileName}", StringComparison.CurrentCultureIgnoreCase))
-                DirectoryMapping[CreateDirectoryListingKey(fullPath.Replace($"\\{IndexFileName}", ""))] = fullPath;
+            if (fullPath.EndsWith($"{Path.DirectorySeparatorChar}{IndexFileName}", StringComparison.CurrentCultureIgnoreCase))
+                DirectoryMapping[CreateDirectoryListingKey(fullPath.Replace($"{Path.DirectorySeparatorChar}{IndexFileName}", ""))] = fullPath;
         }
 
         public virtual string CreateDirectoryListingKey(string item)


### PR DESCRIPTION
Changes the hardcoded directory separator character from \\ to `Path.DirectorySeparatorChar` to fix issue with paths not resolving on non-Windows systems.

Fixes #108