### PR TITLE
Fix Middleware Crash

### DIFF
--- a/src/Grapeseed/ContentType.cs
+++ b/src/Grapeseed/ContentType.cs
@@ -14,6 +14,8 @@ namespace Grapevine
 
         public static ContentType Css = new ContentType("text/css", false);
 
+        public static ContentType FormUrlEncoded = new ContentType("application/x-www-form-urlencoded");
+
         public static ContentType Gif = new ContentType("image/gif");
 
         public static ContentType Html = new ContentType("text/html", false);
@@ -29,6 +31,8 @@ namespace Grapevine
         public static ContentType Mp3 = new ContentType("audio/mpeg");
 
         public static ContentType Mp4 = new ContentType("video/mp4");
+
+        public static ContentType MultipartFormData = new ContentType("multipart/form-data");
 
         public static ContentType Pdf = new ContentType("application/pdf");
 

--- a/src/Grapeseed/Grapeseed.csproj
+++ b/src/Grapeseed/Grapeseed.csproj
@@ -11,7 +11,7 @@
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <AssemblyVersion>$(Version)</AssemblyVersion>
     <FileVersion>$(Version)</FileVersion>
-    <Version>5.0.0-rc.9</Version>
+    <Version>5.0.0-rc.10</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <RepositoryUrl>https://github.com/scottoffen/grapevine</RepositoryUrl>

--- a/src/Grapeseed/HandlerList.cs
+++ b/src/Grapeseed/HandlerList.cs
@@ -1,0 +1,59 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Grapevine
+{
+    public class RequestReceivedEvent : List<RequestReceivedAsyncEventHandler>
+    {
+        public async Task<int> Invoke(IHttpContext context, IRestServer server)
+        {
+            var counter = 0;
+            foreach(var handler in this)
+            {
+                await handler(context, server);
+                counter++;
+                if (context.WasRespondedTo) break;
+            }
+            return counter;
+        }
+
+        public static RequestReceivedEvent operator + (RequestReceivedEvent source, RequestReceivedAsyncEventHandler obj)
+        {
+            source.Add(obj);
+            return source;
+        }
+
+        public static RequestReceivedEvent operator - (RequestReceivedEvent source, RequestReceivedAsyncEventHandler obj)
+        {
+            source.Remove(obj);
+            return source;
+        }
+    }
+
+    public class RequestRoutingEvent : List<RoutingAsyncEventHandler>
+    {
+        public async Task<int> Invoke(IHttpContext context)
+        {
+            var counter = 0;
+            foreach(var handler in this)
+            {
+                await handler(context);
+                counter++;
+                if (context.WasRespondedTo) break;
+            }
+            return counter;
+        }
+
+        public static RequestRoutingEvent operator + (RequestRoutingEvent source, RoutingAsyncEventHandler obj)
+        {
+            source.Add(obj);
+            return source;
+        }
+
+        public static RequestRoutingEvent operator - (RequestRoutingEvent source, RoutingAsyncEventHandler obj)
+        {
+            source.Remove(obj);
+            return source;
+        }
+    }
+}

--- a/src/Grapeseed/HttpRequestExtensions.cs
+++ b/src/Grapeseed/HttpRequestExtensions.cs
@@ -7,12 +7,11 @@ namespace Grapevine
 {
     public static class HttpRequestExtensions
     {
-        private static readonly string _multipartContentType = "multipart/form-data; boundary=";
-        private static readonly int _startIndex = _multipartContentType.Length;
+        private static readonly int _startIndex = ContentType.MultipartFormData.ToString().Length;
 
-        internal static string GetMultipartBoundary(this IHttpRequest request)
+        public static string GetMultipartBoundary(this IHttpRequest request)
         {
-            return (string.IsNullOrWhiteSpace(request.ContentType) || !request.ContentType.StartsWith(_multipartContentType))
+            return (string.IsNullOrWhiteSpace(request.ContentType) || !request.ContentType.StartsWith(ContentType.MultipartFormData))
                 ? string.Empty
                 : request.ContentType.Substring(_startIndex);
         }

--- a/src/Grapeseed/IHttpRequest.cs
+++ b/src/Grapeseed/IHttpRequest.cs
@@ -35,6 +35,11 @@ namespace Grapevine
         CookieCollection Cookies { get; }
 
         /// <summary>
+        /// Gets a boolean value that indicates whether the request has associated body data.
+        /// </summary>
+        bool HasEntityBody { get; }
+
+        /// <summary>
         /// Gets the collection of header name/value pairs sent in the request
         /// </summary>
         NameValueCollection Headers { get; }

--- a/src/Grapeseed/IRestServer.cs
+++ b/src/Grapeseed/IRestServer.cs
@@ -96,7 +96,7 @@ namespace Grapevine
         /// <summary>
         /// Raised after an incoming request is received, but before routing the request.
         /// </summary>
-        event RequestReceivedAsyncEventHandler OnRequestAsync;
+        RequestReceivedEvent OnRequestAsync { get; set; }
 
         /// <summary>
         /// Starts the server, raising BeforeStart and AfterStart events appropriately.

--- a/src/Grapeseed/IRouter.cs
+++ b/src/Grapeseed/IRouter.cs
@@ -48,12 +48,12 @@ namespace Grapevine
         /// <summary>
         /// Raised after a request has completed invoking matching routes
         /// </summary>
-        event RoutingAsyncEventHandler AfterRoutingAsync;
+        RequestRoutingEvent AfterRoutingAsync { get; set; }
 
         /// <summary>
         /// Raised prior to sending any request though matching routes
         /// </summary>
-        event RoutingAsyncEventHandler BeforeRoutingAsync;
+        RequestRoutingEvent BeforeRoutingAsync { get; set; }
 
         /// <summary>
         /// Adds the route to the routing table
@@ -63,7 +63,7 @@ namespace Grapevine
         IRouter Register(IRoute route);
 
         /// <summary>
-        /// Routes the IHttpContext through all enabled registered routes that match the (IHttpConext)state provided
+        /// Routes the IHttpContext through all enabled registered routes that match the (IHttpContext)state provided
         /// </summary>
         /// <param name="state"></param>
         void RouteAsync(object state);

--- a/src/Grapeseed/Router.cs
+++ b/src/Grapeseed/Router.cs
@@ -69,8 +69,8 @@ namespace Grapevine
 
         public IServiceProvider ServiceProvider { get; set; }
 
-        public abstract event RoutingAsyncEventHandler AfterRoutingAsync;
-        public abstract event RoutingAsyncEventHandler BeforeRoutingAsync;
+        public virtual RequestRoutingEvent AfterRoutingAsync { get; set; } = new RequestRoutingEvent();
+        public virtual RequestRoutingEvent BeforeRoutingAsync { get; set; } = new RequestRoutingEvent();
 
         public abstract IRouter Register(IRoute route);
 
@@ -122,9 +122,6 @@ namespace Grapevine
         protected internal readonly IList<IRoute> RegisteredRoutes = new List<IRoute>();
 
         public override IList<IRoute> RoutingTable => RegisteredRoutes.ToList().AsReadOnly();
-
-        public override event RoutingAsyncEventHandler AfterRoutingAsync;
-        public override event RoutingAsyncEventHandler BeforeRoutingAsync;
 
         public Router(ILogger<IRouter> logger)
         {
@@ -182,8 +179,8 @@ namespace Grapevine
             if (!context.CancellationToken.IsCancellationRequested)
             {
                 Logger.LogTrace($"{context.Id} : Invoking before routing handlers for {context.Request.Name}");
-                if (BeforeRoutingAsync != null) await BeforeRoutingAsync.Invoke(context);
-                Logger.LogTrace($"{context.Id} : Before routing handlers invoked for {context.Request.Name}");
+                var beforeCount = (BeforeRoutingAsync != null) ? await BeforeRoutingAsync.Invoke(context) : 0;
+                Logger.LogTrace($"{context.Id} : {beforeCount} Before routing handlers invoked for {context.Request.Name}");
             }
 
             // 3. Iterate over the routes until a response is sent
@@ -203,8 +200,8 @@ namespace Grapevine
             if (!context.CancellationToken.IsCancellationRequested)
             {
                 Logger.LogTrace($"{context.Id} : Invoking after routing handlers for {context.Request.Name}");
-                if (AfterRoutingAsync != null) await AfterRoutingAsync.Invoke(context);
-                Logger.LogTrace($"{context.Id} : After routing handlers invoked for {context.Request.Name}");
+                var afterCount = (AfterRoutingAsync != null) ? await AfterRoutingAsync.Invoke(context) : 0;
+                Logger.LogTrace($"{context.Id} : {afterCount} After routing handlers invoked for {context.Request.Name}");
             }
 
             return count;

--- a/src/Grapevine/Grapevine.csproj
+++ b/src/Grapevine/Grapevine.csproj
@@ -12,7 +12,7 @@
     <PackageTags>rest http api web router client server express json xml embedded</PackageTags>
     <AssemblyVersion>$(Version)</AssemblyVersion>
     <FileVersion>$(Version)</FileVersion>
-    <Version>5.0.0-rc.9</Version>
+    <Version>5.0.0-rc.10</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <RepositoryUrl>https://github.com/scottoffen/grapevine</RepositoryUrl>

--- a/src/Grapevine/HttpRequest.cs
+++ b/src/Grapevine/HttpRequest.cs
@@ -21,6 +21,8 @@ namespace Grapevine
 
         public CookieCollection Cookies => Advanced.Cookies;
 
+        public bool HasEntityBody => Advanced.HasEntityBody;
+
         public NameValueCollection Headers => Advanced.Headers;
 
         public string HostPrefix { get; }

--- a/src/Grapevine/Middleware/FormUrlEncodedData.cs
+++ b/src/Grapevine/Middleware/FormUrlEncodedData.cs
@@ -6,7 +6,7 @@ namespace Grapevine.Middleware
     {
         public async static Task Parse(IHttpContext context, IRestServer server)
         {
-            if (context.Request.ContentType != "application/x-www-form-urlencoded") return;
+            if ((context.Request.ContentType != ContentType.FormUrlEncoded) || (!context.Request.HasEntityBody)) return;
             context.Locals.TryAdd("FormData", await context.Request.ParseFormUrlEncodedData());
         }
     }

--- a/src/Grapevine/RestServer.cs
+++ b/src/Grapevine/RestServer.cs
@@ -39,7 +39,7 @@ namespace Grapevine
         public abstract event ServerEventHandler AfterStopping;
         public abstract event ServerEventHandler BeforeStarting;
         public abstract event ServerEventHandler BeforeStopping;
-        public abstract event RequestReceivedAsyncEventHandler OnRequestAsync;
+        public virtual RequestReceivedEvent OnRequestAsync { get; set; } = new RequestReceivedEvent();
 
         public abstract void Dispose();
 
@@ -87,7 +87,6 @@ namespace Grapevine
         public override event ServerEventHandler AfterStopping;
         public override event ServerEventHandler BeforeStarting;
         public override event ServerEventHandler BeforeStopping;
-        public override event RequestReceivedAsyncEventHandler OnRequestAsync;
 
         public RestServer(IRouter router, IRouteScanner scanner, ILogger<IRestServer> logger)
         {
@@ -267,8 +266,8 @@ namespace Grapevine
             try
             {
                 Logger.LogTrace($"{context.Id} : Invoking OnRequest Handlers for {context.Request.Name}");
-                if (OnRequestAsync != null) await OnRequestAsync.Invoke(context, this);
-                Logger.LogTrace($"{context.Id} : OnRequest Handlers Invoked for {context.Request.Name}");
+                var count = (OnRequestAsync != null) ? await OnRequestAsync.Invoke(context, this) : 0;
+                Logger.LogTrace($"{context.Id} : {count} OnRequest Handlers Invoked for {context.Request.Name}");
             }
             catch (System.Net.HttpListenerException hl) when (hl.ErrorCode == 1229)
             {


### PR DESCRIPTION
With the additions of helper methods to parse form data, middleware started crashing when static content was being server. This lead to the discovery that the was middleware was designed could cause a number of failure scenarios. This fixes that.

Adds `HasEntityBody` property to the request and new content types `ContentType.FormData` and `ContentType.MultipartFormData` to remove some magic strings in the new form parsing additions.