### PR TITLE
Replace HttpListener for .NET 6.0+

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "7.0.400",
+    "rollForward": "minor"
+  }
+}

--- a/src/Grapeseed/ContentFolder.cs
+++ b/src/Grapeseed/ContentFolder.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
@@ -162,18 +162,17 @@ namespace Grapevine
             Watcher?.Dispose();
         }
 
-        public async override Task SendFileAsync(IHttpContext context)
+        public override async Task SendFileAsync(IHttpContext context)
         {
             await SendFileAsync(context, null);
         }
 
-        public async override Task SendFileAsync(IHttpContext context, string filename)
+        public override async Task SendFileAsync(IHttpContext context, string filename)
         {
             PopulateDirectoryListing();
 
-            if (DirectoryMapping.ContainsKey(context.Request.Endpoint))
+            if (DirectoryMapping.TryGetValue(context.Request.Endpoint, out var filepath))
             {
-                var filepath = DirectoryMapping[context.Request.Endpoint];
                 context.Response.StatusCode = HttpStatusCode.Ok;
 
                 var lastModified = File.GetLastWriteTimeUtc(filepath).ToString("R");

--- a/src/Grapeseed/Grapeseed.csproj
+++ b/src/Grapeseed/Grapeseed.csproj
@@ -12,7 +12,7 @@
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <AssemblyVersion>$(Version)</AssemblyVersion>
     <FileVersion>$(Version)</FileVersion>
-    <Version>6.0.0-beta</Version>
+    <Version>6.0.0-beta2</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <RepositoryUrl>https://github.com/scottoffen/grapevine</RepositoryUrl>

--- a/src/Grapeseed/HttpMethod.cs
+++ b/src/Grapeseed/HttpMethod.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -19,18 +19,21 @@ namespace Grapevine
         public static HttpMethod Connect { get; } = new HttpMethod("CONNECT");
 
         // for implicit conversions
-        private static readonly Dictionary<string, HttpMethod> _methods = new Dictionary<string, HttpMethod>();
+        private static readonly Dictionary<string, HttpMethod> _methods;
 
         static HttpMethod()
         {
-            var mtype = typeof(HttpMethod);
-            var staticMethods = typeof(HttpMethod).GetFields(BindingFlags.Public | BindingFlags.Static)
-                .Select(f => f.GetValue(null))
-                .Where(f => f.GetType() == mtype)
-                .Cast<HttpMethod>()
-                .ToList();
-
-            foreach (var method in staticMethods) _methods.Add(method.ToString(), method);
+            _methods = new Dictionary<string, HttpMethod>();
+            _methods.Add("POST", Post);
+            _methods.Add("PUT", Put);
+            _methods.Add("DELETE", Delete);
+            _methods.Add("HEAD", Head);
+            _methods.Add("GET", Get);
+            _methods.Add("ANY", Any);
+            _methods.Add("OPTIONS", Options);
+            _methods.Add("TRACE", Trace);
+            _methods.Add("PATCH", Patch);
+            _methods.Add("CONNECT", Connect);
         }
 
         public static bool operator ==(HttpMethod left, HttpMethod right)
@@ -63,11 +66,12 @@ namespace Grapevine
 
     public partial class HttpMethod : IEquatable<HttpMethod>
     {
-        private int _hashcode;
+        private readonly int _hashcode;
 
         public HttpMethod(string method)
         {
             Method = method.Trim().ToUpper();
+            _hashcode = StringComparer.OrdinalIgnoreCase.GetHashCode(Method);
         }
 
         public string Method { get; }
@@ -92,7 +96,6 @@ namespace Grapevine
 
         public override int GetHashCode()
         {
-            if (_hashcode == 0) StringComparer.OrdinalIgnoreCase.GetHashCode(Method);
             return _hashcode;
         }
 

--- a/src/Grapeseed/IHttpResponse.cs
+++ b/src/Grapeseed/IHttpResponse.cs
@@ -1,7 +1,6 @@
-using System;
+﻿using System;
 using System.IO;
 using System.Linq;
-using System.Net;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -32,12 +31,12 @@ namespace Grapevine
         /// <summary>
         /// Gets or sets the collection of cookies returned with the response
         /// </summary>
-        CookieCollection Cookies { get; set; }
+        System.Net.CookieCollection Cookies { get; set; }
 
         /// <summary>
         /// Gets or sets the collection of header name/value pairs returned by the server
         /// </summary>
-        WebHeaderCollection Headers { get; set; }
+        System.Net.WebHeaderCollection Headers { get; set; }
 
         string RedirectLocation { get; set; }
 
@@ -77,7 +76,7 @@ namespace Grapevine
         /// Adds the specified Cookie to the collection of cookies for this response
         /// </summary>
         /// <param name="cookie"></param>
-        void AppendCookie(Cookie cookie);
+        void AppendCookie(System.Net.Cookie cookie);
 
         /// <summary>
         /// Appends a value to the specified HTTP header to be sent with this response
@@ -102,7 +101,7 @@ namespace Grapevine
         /// Adds or updates a Cookie in the collection of cookies sent with this response
         /// </summary>
         /// <param name="cookie"></param>
-        void SetCookie(Cookie cookie);
+        void SetCookie(System.Net.Cookie cookie);
     }
 
     public static class IHttpResponseExtensions

--- a/src/Grapeseed/ProblemDetailsContentTypes.cs
+++ b/src/Grapeseed/ProblemDetailsContentTypes.cs
@@ -1,4 +1,4 @@
-namespace Grapevine
+﻿namespace Grapevine
 {
     public interface IProblemDetailsContentTypes
     {
@@ -8,8 +8,8 @@ namespace Grapevine
 
     internal class ProblemDetailsContentTypes : IProblemDetailsContentTypes
     {
-        public ContentType Json { get; } = new ContentType("application/problem+json", false, "UTF-8");
+        public ContentType Json { get; } = new ContentType("application/problem+json", "", false, "UTF-8");
 
-        public ContentType Xml { get; } = new ContentType("application/problem+xml", false, "UTF-8");
+        public ContentType Xml { get; } = new ContentType("application/problem+xml", "", false, "UTF-8");
     }
 }

--- a/src/Grapevine/GlobalUsings.cs
+++ b/src/Grapevine/GlobalUsings.cs
@@ -1,0 +1,5 @@
+﻿#if NET6_0_OR_GREATER
+global using SpaceWizards.HttpListener;
+#else
+global using System.Net;
+#endif

--- a/src/Grapevine/Grapevine.csproj
+++ b/src/Grapevine/Grapevine.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard2.1;net5.0;net6.0</TargetFrameworks>
     <NoWarn>NETSDK1138</NoWarn>
+    <LangVersion>10.0</LangVersion>
     <PackageId>Grapevine</PackageId>
     <PackageVersion>$(Version)</PackageVersion>
     <Authors>Scott Offen</Authors>
@@ -13,7 +14,7 @@
     <PackageTags>rest http api web router client server express json xml embedded</PackageTags>
     <AssemblyVersion>$(Version)</AssemblyVersion>
     <FileVersion>$(Version)</FileVersion>
-    <Version>6.0.0-beta</Version>
+    <Version>6.0.0-beta2</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <RepositoryUrl>https://github.com/scottoffen/grapevine</RepositoryUrl>
@@ -62,6 +63,12 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Grapeseed\Grapeseed.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="SpaceWizards.HttpListener">
+      <Version>0.1.0</Version>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/src/Grapevine/HttpContext.cs
+++ b/src/Grapevine/HttpContext.cs
@@ -1,5 +1,4 @@
-using System;
-using System.Net;
+﻿using System;
 using System.Threading;
 
 namespace Grapevine

--- a/src/Grapevine/HttpRequest.cs
+++ b/src/Grapevine/HttpRequest.cs
@@ -1,8 +1,7 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.IO;
-using System.Net;
 using System.Text;
 
 namespace Grapevine
@@ -19,7 +18,7 @@ namespace Grapevine
 
         public string ContentType => Advanced.ContentType;
 
-        public CookieCollection Cookies => Advanced.Cookies;
+        public System.Net.CookieCollection Cookies => Advanced.Cookies;
 
         public bool HasEntityBody => Advanced.HasEntityBody;
 
@@ -43,7 +42,7 @@ namespace Grapevine
 
         public string RawUrl => Advanced.RawUrl;
 
-        public IPEndPoint RemoteEndPoint => Advanced.RemoteEndPoint;
+        public System.Net.IPEndPoint RemoteEndPoint => Advanced.RemoteEndPoint;
 
         public Uri Url => Advanced.Url;
 

--- a/src/Grapevine/HttpResponse.cs
+++ b/src/Grapevine/HttpResponse.cs
@@ -1,5 +1,4 @@
-using System;
-using System.Net;
+﻿using System;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -29,13 +28,13 @@ namespace Grapevine
             set { Advanced.ContentType = value; }
         }
 
-        public CookieCollection Cookies
+        public System.Net.CookieCollection Cookies
         {
             get { return Advanced.Cookies; }
             set { Advanced.Cookies = value; }
         }
 
-        public WebHeaderCollection Headers
+        public System.Net.WebHeaderCollection Headers
         {
             get { return Advanced.Headers; }
             set { Advanced.Headers = value; }
@@ -79,7 +78,7 @@ namespace Grapevine
 
         public void AddHeader(string name, string value) => Advanced.AddHeader(name, value);
 
-        public void AppendCookie(Cookie cookie) => Advanced.AppendCookie(cookie);
+        public void AppendCookie(System.Net.Cookie cookie) => Advanced.AppendCookie(cookie);
 
         public void AppendHeader(string name, string value) => Advanced.AppendHeader(name, value);
 
@@ -91,7 +90,7 @@ namespace Grapevine
 
         public abstract Task SendResponseAsync(byte[] contents);
 
-        public void SetCookie(Cookie cookie) => Advanced.SetCookie(cookie);
+        public void SetCookie(System.Net.Cookie cookie) => Advanced.SetCookie(cookie);
 
         public HttpResponseBase(HttpListenerResponse response)
         {

--- a/src/Grapevine/ListenerPrefixCollection.cs
+++ b/src/Grapevine/ListenerPrefixCollection.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Net;
@@ -11,13 +11,14 @@ namespace Grapevine
 
         public bool IsReadOnly => PrefixCollection.IsReadOnly;
 
-        public bool IsSynchronized => PrefixCollection.IsSynchronized;
-
-        protected HttpListenerPrefixCollection PrefixCollection;
-
-        public ListenerPrefixCollection (HttpListenerPrefixCollection prefixes)
+        protected ICollection<string> PrefixCollection
         {
-            PrefixCollection = prefixes;
+            get;
+        }
+
+        public ListenerPrefixCollection(ICollection<string> prefixCollection)
+        {
+            PrefixCollection = prefixCollection;
         }
 
         public void Add(string item) => PrefixCollection.Add(item);
@@ -25,8 +26,6 @@ namespace Grapevine
         public void Clear() => PrefixCollection.Clear();
 
         public bool Contains(string item) => PrefixCollection.Contains(item);
-
-        public void CopyTo(Array array, int arrayIndex) => PrefixCollection.CopyTo(array, arrayIndex);
 
         public void CopyTo(string[] array, int arrayIndex) => PrefixCollection.CopyTo(array, arrayIndex);
 

--- a/src/Grapevine/RestServer.cs
+++ b/src/Grapevine/RestServer.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Threading;
@@ -105,6 +105,7 @@ namespace Grapevine
             Listener = new HttpListener();
             Prefixes = new ListenerPrefixCollection(Listener.Prefixes);
             RequestHandler = new Thread(RequestListenerAsync);
+            RequestHandler.Name = nameof(RequestListenerAsync);
         }
 
         public override void Dispose()
@@ -162,7 +163,7 @@ namespace Grapevine
 
                 exceptionWasThrown = true;
 
-                var message = $"One or more ports are already in use by another application.";
+                var message = $"One or more ports are already in use by another application - this is bad.";
                 var exception = new ArgumentException(message, hl);
 
                 Logger.LogCritical(exception, message);
@@ -223,13 +224,13 @@ namespace Grapevine
             }
         }
 
-        protected async void RequestListenerAsync()
+        protected void RequestListenerAsync()
         {
             while (Listener.IsListening)
             {
                 try
                 {
-                    var context = await Listener.GetContextAsync();
+                    var context = Listener.GetContext();
                     ThreadPool.QueueUserWorkItem(RequestHandlerAsync, context);
                 }
                 catch (HttpListenerException hl) when (hl.ErrorCode == 995 && (IsStopping || !IsListening))

--- a/src/Grapevine/RestServer.cs
+++ b/src/Grapevine/RestServer.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Net;
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 
 namespace Grapevine
@@ -20,7 +20,16 @@ namespace Grapevine
 
         public ServerOptions Options { get; } = new ServerOptions
         {
-            HttpContextFactory = (state, token) => new HttpContext(state as HttpListenerContext, token)
+            HttpContextFactory = (state, token) =>
+            {
+                HttpListenerContext context = state as HttpListenerContext;
+                if (context == null)
+                {
+                    // Could be Task<HttpListenerContext>, but using that result causes some infinite recursion.
+                    throw new InvalidOperationException($"Result is not of expected type {nameof(HttpListenerContext)}, but {state.GetType().Name}");
+                }
+                return new HttpContext(context, token);
+            }
         };
 
         public virtual IListenerPrefixCollection Prefixes { get; }

--- a/src/Grapevine/RestServerBuilder.cs
+++ b/src/Grapevine/RestServerBuilder.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;

--- a/src/Grapevine/RouterBaseExtensions.cs
+++ b/src/Grapevine/RouterBaseExtensions.cs
@@ -1,5 +1,4 @@
-using System.Net;
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 
 namespace Grapevine
 {

--- a/src/Samples/Program.cs
+++ b/src/Samples/Program.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Diagnostics;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -30,9 +30,7 @@ namespace Samples
                     sb.Append($"* Server listening on {string.Join(", ", server.Prefixes)}{Environment.NewLine}");
                     sb.Append($"* Stop server by going to {server.Prefixes.First()}api/stop{Environment.NewLine}");
                     sb.Append($"********************************************************************************{Environment.NewLine}");
-                    s.Logger.LogDebug(sb.ToString());
-
-                    // new InteractiveShell().Run(server);
+                    s.Logger.LogInformation(sb.ToString());
 
                     OpenBrowser(s.Prefixes.First());
                 };

--- a/src/Samples/Resources/HelloResource.cs
+++ b/src/Samples/Resources/HelloResource.cs
@@ -1,4 +1,4 @@
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Grapevine;
 using Microsoft.Extensions.Logging;
 

--- a/src/Samples/Startup.cs
+++ b/src/Samples/Startup.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.IO;
 using Grapevine;
 using Microsoft.Extensions.Configuration;
@@ -26,6 +26,7 @@ namespace Samples
             {
                 loggingBuilder.ClearProviders();
                 loggingBuilder.AddNLog(new NLogLoggingConfiguration(Configuration.GetSection("NLog")));
+                loggingBuilder.AddConsole();
             });
 
             services.AddHttpClient<GitHubClient>(c =>


### PR DESCRIPTION
This replaces the legacy `System.Net.HttpListener` with `SpaceWizzards.HttpListener.HttpListener` for .NET 6.0 and above. This replacement implementation is fully managed and does not use any poorly maintained Windows IIS components under the hood. It also no longer requires admin rights (or complex netsh rules) to create the listener and "just works". The only probable downside I can think of is that the network port cannot be shared directly with this implementation, but when something as lightweight as Grapevine is used, that's probably not intended anyway. 

Also includes some fixes for `ContentType`, the old implementation for the default list wasn't working. This resulted in html files being delivered as binary, which then were downloaded by the browser as files instead of displayed as content. 