### PR TITLE
Updated attribute inheritance check in RouteScanner

### DIFF
--- a/src/Grapeseed/RouteScanner.cs
+++ b/src/Grapeseed/RouteScanner.cs
@@ -196,7 +196,7 @@ namespace Grapevine
         public static IEnumerable<Type> GetQualifiedTypes(Assembly assembly)
         {
             foreach (var type in assembly.GetTypes()
-                .Where(t => t.IsClass && t.IsDefined(typeof(RestResourceAttribute), false))
+                .Where(t => t.IsClass && t.IsDefined(typeof(RestResourceAttribute), true))
                 .OrderBy(t => t.Name)) yield return type;
         }
 


### PR DESCRIPTION
- Modified the condition to check for inherited attributes in GetQualifiedTypes method
- This change allows scanning of classes that inherit from a class with RestResourceAttribute
- Will follow this up in https://github.com/scottoffen/grapevine/discussions/122.