### PR TITLE
Adds MCP extension for Grapevine

### DIFF
--- a/src/Grapevine.Extensions.Mcp/Grapevine.Extensions.Mcp.csproj
+++ b/src/Grapevine.Extensions.Mcp/Grapevine.Extensions.Mcp.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net5.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0</TargetFrameworks>
+    <UseAppHost>false</UseAppHost>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>disable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -14,9 +15,21 @@
     <RootNamespace>ModelContextProtocol.AspNetCore</RootNamespace>
     <Version>5.0.2</Version>
     <Authors>Gao Yang</Authors>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <RepositoryUrl>https://github.com/scottoffen/grapevine</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageProjectUrl>https://scottoffen.github.io/grapevine/</PackageProjectUrl>
+    <PackageIcon>grapevine.png</PackageIcon>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>
 
   <ItemGroup>
+    <None Include="..\..\LICENSE" Pack="true" Visible="false" PackagePath="" />
+    <None Include="..\..\grapevine.png" Pack="true" PackagePath="\" />
     <None Include="README.md" pack="true" PackagePath="\" />
   </ItemGroup>
 

--- a/src/Grapevine.Extensions.Mcp/Grapevine.Extensions.Mcp.csproj
+++ b/src/Grapevine.Extensions.Mcp/Grapevine.Extensions.Mcp.csproj
@@ -12,14 +12,13 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <IsAotCompatible>true</IsAotCompatible>
     <LangVersion>8</LangVersion>
-    <RootNamespace>ModelContextProtocol.AspNetCore</RootNamespace>
+    <RootNamespace>Grapevine.Extensions.Mcp</RootNamespace>
     <Version>5.0.2</Version>
     <Authors>Gao Yang</Authors>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
-    <RepositoryUrl>https://github.com/scottoffen/grapevine</RepositoryUrl>
+    <RepositoryUrl>https://github.com/flyingbag/grapevine</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <PackageProjectUrl>https://scottoffen.github.io/grapevine/</PackageProjectUrl>
     <PackageIcon>grapevine.png</PackageIcon>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>

--- a/src/Grapevine.Extensions.Mcp/Grapevine.Extensions.Mcp.csproj
+++ b/src/Grapevine.Extensions.Mcp/Grapevine.Extensions.Mcp.csproj
@@ -2,16 +2,18 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard2.1;net5.0;net6.0;net7.0</TargetFrameworks>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>disable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsPackable>true</IsPackable>
     <PackageId>Grapevine.Extensions.Mcp</PackageId>
-    <Description>ASP.NET Core extensions for the C# Model Context Protocol (MCP) SDK.</Description>
+    <Description>Grapevine extensions for the C# Model Context Protocol (MCP) SDK.</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <IsAotCompatible>true</IsAotCompatible>
-    <LangVersion>12</LangVersion>
+    <LangVersion>8</LangVersion>
     <RootNamespace>ModelContextProtocol.AspNetCore</RootNamespace>
+    <Version>5.0.2</Version>
+    <Authors>Gao Yang</Authors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Grapevine.Extensions.Mcp/Grapevine.Extensions.Mcp.csproj
+++ b/src/Grapevine.Extensions.Mcp/Grapevine.Extensions.Mcp.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net5.0;net6.0;net7.0</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <IsPackable>true</IsPackable>
+    <PackageId>Grapevine.Extensions.Mcp</PackageId>
+    <Description>ASP.NET Core extensions for the C# Model Context Protocol (MCP) SDK.</Description>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <IsAotCompatible>true</IsAotCompatible>
+    <LangVersion>12</LangVersion>
+    <RootNamespace>ModelContextProtocol.AspNetCore</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="README.md" pack="true" PackagePath="\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.4" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.4" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.0-preview.3.25171.5" />
+    <PackageReference Include="ModelContextProtocol" Version="0.1.0-preview.9" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Grapeseed\Grapeseed.csproj" />
+    <ProjectReference Include="..\Grapevine\Grapevine.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Grapevine.Extensions.Mcp/HttpMcpServerBuilderExtensions.cs
+++ b/src/Grapevine.Extensions.Mcp/HttpMcpServerBuilderExtensions.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+using ModelContextProtocol.Server;
+
+namespace Grapevine.Extensions.Mcp;
+
+/// <summary>
+/// Provides methods for configuring HTTP MCP servers via dependency injection.
+/// </summary>
+public static class HttpMcpServerBuilderExtensions
+{
+    /// <summary>
+    /// Adds the services necessary for <see cref="M:McpEndpointRouteBuilderExtensions.MapMcp"/>
+    /// to handle MCP requests and sessions using the MCP HTTP Streaming transport. For more information on configuring the underlying HTTP server
+    /// to control things like port binding custom TLS certificates, see the <see href="https://learn.microsoft.com/aspnet/core/fundamentals/minimal-apis">Minimal APIs quick reference</see>.
+    /// </summary>
+    /// <param name="builder">The builder instance.</param>
+    /// <param name="configureOptions">Configures options for the HTTP Streaming transport. This allows configuring per-session
+    /// <see cref="McpServerOptions"/> and running logic before and after a session.</param>
+    /// <returns>The builder provided in <paramref name="builder"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="builder"/> is <see langword="null"/>.</exception>
+    public static IMcpServerBuilder WithHttpTransport(this IMcpServerBuilder builder, Action<HttpServerTransportOptions>? configureOptions = null)
+    {
+        if (builder is null)
+        {
+            throw new ArgumentNullException(nameof(builder));
+        }
+        builder.Services.TryAddSingleton<StreamableHttpHandler>();
+
+        if (configureOptions is not null)
+        {
+            builder.Services.Configure(configureOptions);
+        }
+
+        return builder;
+    }
+}

--- a/src/Grapevine.Extensions.Mcp/HttpMcpServerBuilderExtensions.cs
+++ b/src/Grapevine.Extensions.Mcp/HttpMcpServerBuilderExtensions.cs
@@ -1,38 +1,43 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using System;
+
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
 using ModelContextProtocol.Server;
 
-namespace Grapevine.Extensions.Mcp;
-
-/// <summary>
-/// Provides methods for configuring HTTP MCP servers via dependency injection.
-/// </summary>
-public static class HttpMcpServerBuilderExtensions
+namespace Grapevine.Extensions.Mcp
 {
     /// <summary>
-    /// Adds the services necessary for <see cref="M:McpEndpointRouteBuilderExtensions.MapMcp"/>
-    /// to handle MCP requests and sessions using the MCP HTTP Streaming transport. For more information on configuring the underlying HTTP server
-    /// to control things like port binding custom TLS certificates, see the <see href="https://learn.microsoft.com/aspnet/core/fundamentals/minimal-apis">Minimal APIs quick reference</see>.
+    /// Provides methods for configuring HTTP MCP servers via dependency injection.
     /// </summary>
-    /// <param name="builder">The builder instance.</param>
-    /// <param name="configureOptions">Configures options for the HTTP Streaming transport. This allows configuring per-session
-    /// <see cref="McpServerOptions"/> and running logic before and after a session.</param>
-    /// <returns>The builder provided in <paramref name="builder"/>.</returns>
-    /// <exception cref="ArgumentNullException"><paramref name="builder"/> is <see langword="null"/>.</exception>
-    public static IMcpServerBuilder WithHttpTransport(this IMcpServerBuilder builder, Action<HttpServerTransportOptions>? configureOptions = null)
+    public static class HttpMcpServerBuilderExtensions
     {
-        if (builder is null)
+        /// <summary>
+        /// Adds the services necessary for <see cref="M:McpEndpointRouteBuilderExtensions.MapMcp"/>
+        /// to handle MCP requests and sessions using the MCP HTTP Streaming transport. For more information on configuring the underlying HTTP server
+        /// to control things like port binding custom TLS certificates, see the <see href="https://learn.microsoft.com/aspnet/core/fundamentals/minimal-apis">Minimal APIs quick reference</see>.
+        /// </summary>
+        /// <param name="builder">The builder instance.</param>
+        /// <param name="configureOptions">Configures options for the HTTP Streaming transport. This allows configuring per-session
+        /// <see cref="McpServerOptions"/> and running logic before and after a session.</param>
+        /// <returns>The builder provided in <paramref name="builder"/>.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="builder"/> is <see langword="null"/>.</exception>
+        public static IMcpServerBuilder WithHttpTransport(this IMcpServerBuilder builder,
+            Action<HttpServerTransportOptions>? configureOptions = null)
         {
-            throw new ArgumentNullException(nameof(builder));
-        }
-        builder.Services.TryAddSingleton<StreamableHttpHandler>();
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
 
-        if (configureOptions is not null)
-        {
-            builder.Services.Configure(configureOptions);
-        }
+            builder.Services.TryAddSingleton<StreamableHttpHandler>();
 
-        return builder;
+            if (configureOptions != null)
+            {
+                builder.Services.Configure(configureOptions);
+            }
+
+            return builder;
+        }
     }
 }

--- a/src/Grapevine.Extensions.Mcp/HttpMcpSession.cs
+++ b/src/Grapevine.Extensions.Mcp/HttpMcpSession.cs
@@ -1,0 +1,41 @@
+﻿using ModelContextProtocol.Protocol.Transport;
+using System.Security.Claims;
+using System.Security.Principal;
+
+namespace Grapevine.Extensions.Mcp;
+
+internal class HttpMcpSession
+{
+    public HttpMcpSession(SseResponseStreamTransport transport, IPrincipal user)
+    {
+        Transport = transport;
+        var claimsUser = user as ClaimsPrincipal ?? new ClaimsPrincipal();
+        UserIdClaim = GetUserIdClaim(claimsUser);
+    }
+
+    public SseResponseStreamTransport Transport { get; }
+    public (string Type, string Value, string Issuer)? UserIdClaim { get; }
+
+    public bool HasSameUserId(ClaimsPrincipal user)
+        => UserIdClaim == GetUserIdClaim(user);
+
+    // SignalR only checks for ClaimTypes.NameIdentifier in HttpConnectionDispatcher, but AspNetCore.Antiforgery checks that plus the sub and UPN claims.
+    // However, we short-circuit unlike antiforgery since we expect to call this to verify MCP messages a lot more frequently than
+    // verifying antiforgery tokens from <form> posts.
+    private static (string Type, string Value, string Issuer)? GetUserIdClaim(ClaimsPrincipal user)
+    {
+        if (user?.Identity?.IsAuthenticated != true)
+        {
+            return null;
+        }
+
+        var claim = user.FindFirst(ClaimTypes.NameIdentifier) ?? user.FindFirst("sub") ?? user.FindFirst(ClaimTypes.Upn);
+
+        if (claim is { } idClaim)
+        {
+            return (idClaim.Type, idClaim.Value, idClaim.Issuer);
+        }
+
+        return null;
+    }
+}

--- a/src/Grapevine.Extensions.Mcp/HttpMcpSession.cs
+++ b/src/Grapevine.Extensions.Mcp/HttpMcpSession.cs
@@ -16,13 +16,13 @@ internal class HttpMcpSession
     public SseResponseStreamTransport Transport { get; }
     public (string Type, string Value, string Issuer)? UserIdClaim { get; }
 
-    public bool HasSameUserId(ClaimsPrincipal user)
-        => UserIdClaim == GetUserIdClaim(user);
+    public bool HasSameUserId(IPrincipal user)
+        => UserIdClaim == GetUserIdClaim(user as ClaimsPrincipal);
 
     // SignalR only checks for ClaimTypes.NameIdentifier in HttpConnectionDispatcher, but AspNetCore.Antiforgery checks that plus the sub and UPN claims.
     // However, we short-circuit unlike antiforgery since we expect to call this to verify MCP messages a lot more frequently than
     // verifying antiforgery tokens from <form> posts.
-    private static (string Type, string Value, string Issuer)? GetUserIdClaim(ClaimsPrincipal user)
+    private static (string Type, string Value, string Issuer)? GetUserIdClaim(ClaimsPrincipal? user)
     {
         if (user?.Identity?.IsAuthenticated != true)
         {

--- a/src/Grapevine.Extensions.Mcp/HttpServerTransportOptions.cs
+++ b/src/Grapevine.Extensions.Mcp/HttpServerTransportOptions.cs
@@ -1,23 +1,28 @@
-﻿using ModelContextProtocol.Server;
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
 
-namespace Grapevine.Extensions.Mcp;
+using ModelContextProtocol.Server;
 
-/// <summary>
-/// Configuration options for <see cref="M:McpEndpointRouteBuilderExtensions.MapMcp"/>.
-/// which implements the Streaming HTTP transport for the Model Context Protocol.
-/// See the protocol specification for details on the Streamable HTTP transport. <see href="https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http"/>
-/// </summary>
-public class HttpServerTransportOptions
+namespace Grapevine.Extensions.Mcp
 {
     /// <summary>
-    /// Gets or sets an optional asynchronous callback to configure per-session <see cref="McpServerOptions"/>
-    /// with access to the <see cref="HttpContext"/> of the request that initiated the session.
+    /// Configuration options for <see cref="M:McpEndpointRouteBuilderExtensions.MapMcp"/>.
+    /// which implements the Streaming HTTP transport for the Model Context Protocol.
+    /// See the protocol specification for details on the Streamable HTTP transport. <see href="https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http"/>
     /// </summary>
-    public Func<HttpContext, McpServerOptions, CancellationToken, Task>? ConfigureSessionOptions { get; set; }
+    public class HttpServerTransportOptions
+    {
+        /// <summary>
+        /// Gets or sets an optional asynchronous callback to configure per-session <see cref="McpServerOptions"/>
+        /// with access to the <see cref="HttpContext"/> of the request that initiated the session.
+        /// </summary>
+        public Func<HttpContext, McpServerOptions, CancellationToken, Task>? ConfigureSessionOptions { get; set; }
 
-    /// <summary>
-    /// Gets or sets an optional asynchronous callback for running new MCP sessions manually.
-    /// This is useful for running logic before a sessions starts and after it completes.
-    /// </summary>
-    public Func<HttpContext, IMcpServer, CancellationToken, Task>? RunSessionHandler { get; set; }
+        /// <summary>
+        /// Gets or sets an optional asynchronous callback for running new MCP sessions manually.
+        /// This is useful for running logic before a sessions starts and after it completes.
+        /// </summary>
+        public Func<HttpContext, IMcpServer, CancellationToken, Task>? RunSessionHandler { get; set; }
+    }
 }

--- a/src/Grapevine.Extensions.Mcp/HttpServerTransportOptions.cs
+++ b/src/Grapevine.Extensions.Mcp/HttpServerTransportOptions.cs
@@ -1,0 +1,23 @@
+﻿using ModelContextProtocol.Server;
+
+namespace Grapevine.Extensions.Mcp;
+
+/// <summary>
+/// Configuration options for <see cref="M:McpEndpointRouteBuilderExtensions.MapMcp"/>.
+/// which implements the Streaming HTTP transport for the Model Context Protocol.
+/// See the protocol specification for details on the Streamable HTTP transport. <see href="https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http"/>
+/// </summary>
+public class HttpServerTransportOptions
+{
+    /// <summary>
+    /// Gets or sets an optional asynchronous callback to configure per-session <see cref="McpServerOptions"/>
+    /// with access to the <see cref="HttpContext"/> of the request that initiated the session.
+    /// </summary>
+    public Func<HttpContext, McpServerOptions, CancellationToken, Task>? ConfigureSessionOptions { get; set; }
+
+    /// <summary>
+    /// Gets or sets an optional asynchronous callback for running new MCP sessions manually.
+    /// This is useful for running logic before a sessions starts and after it completes.
+    /// </summary>
+    public Func<HttpContext, IMcpServer, CancellationToken, Task>? RunSessionHandler { get; set; }
+}

--- a/src/Grapevine.Extensions.Mcp/McpEndpointRouteBuilderExtensions.cs
+++ b/src/Grapevine.Extensions.Mcp/McpEndpointRouteBuilderExtensions.cs
@@ -1,0 +1,32 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Grapevine;
+
+namespace Grapevine.Extensions.Mcp;
+
+/// <summary>
+/// Provides extension methods for <see cref="IEndpointRouteBuilder"/> to add MCP endpoints.
+/// </summary>
+public static class McpEndpointRouteBuilderExtensions
+{
+    /// <summary>
+    /// Sets up endpoints for handling MCP HTTP Streaming transport.
+    /// See <see href="https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http">the protocol specification</see> for details about the Streamable HTTP transport.
+    /// </summary>
+    /// <param name="endpoints">The web application to attach MCP HTTP endpoints.</param>
+    /// <param name="pattern">The route pattern prefix to map to.</param>
+    /// <returns>Returns a builder for configuring additional endpoint conventions like authorization policies.</returns>
+    public static IRestServer MapMcp(this IRestServer server, string pattern = "")
+    {
+        var handler = server.Router.ServiceProvider.GetService<StreamableHttpHandler>() ??
+            throw new InvalidOperationException("You must call WithHttpTransport(). Unable to find required services. Call builder.Services.AddMcpServer().WithHttpTransport() in application startup code.");
+
+        var prefix = pattern?.TrimEnd('/') ?? "";
+        server.Router.Register(
+            new Route(ctx => handler.HandleRequestAsync((HttpContext)ctx), "Get", prefix));
+        server.Router.Register(
+            new Route(ctx => handler.HandleRequestAsync((HttpContext)ctx), "Get", prefix + "/sse"));
+        server.Router.Register(
+            new Route(ctx => handler.HandleRequestAsync((HttpContext)ctx), "Post", prefix + "/message"));
+        return server;
+    }
+}

--- a/src/Grapevine.Extensions.Mcp/McpEndpointRouteBuilderExtensions.cs
+++ b/src/Grapevine.Extensions.Mcp/McpEndpointRouteBuilderExtensions.cs
@@ -1,32 +1,42 @@
-﻿using Microsoft.Extensions.DependencyInjection;
-using Grapevine;
+﻿using System;
 
-namespace Grapevine.Extensions.Mcp;
+using Microsoft.Extensions.DependencyInjection;
 
-/// <summary>
-/// Provides extension methods for <see cref="IEndpointRouteBuilder"/> to add MCP endpoints.
-/// </summary>
-public static class McpEndpointRouteBuilderExtensions
+namespace Grapevine.Extensions.Mcp
 {
     /// <summary>
-    /// Sets up endpoints for handling MCP HTTP Streaming transport.
-    /// See <see href="https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http">the protocol specification</see> for details about the Streamable HTTP transport.
+    /// Provides extension methods for <see cref="IEndpointRouteBuilder"/> to add MCP endpoints.
     /// </summary>
-    /// <param name="endpoints">The web application to attach MCP HTTP endpoints.</param>
-    /// <param name="pattern">The route pattern prefix to map to.</param>
-    /// <returns>Returns a builder for configuring additional endpoint conventions like authorization policies.</returns>
-    public static IRestServer MapMcp(this IRestServer server, string pattern = "")
+    public static class McpEndpointRouteBuilderExtensions
     {
-        var handler = server.Router.ServiceProvider.GetService<StreamableHttpHandler>() ??
-            throw new InvalidOperationException("You must call WithHttpTransport(). Unable to find required services. Call builder.Services.AddMcpServer().WithHttpTransport() in application startup code.");
+        /// <summary>
+        /// Sets up endpoints for handling MCP HTTP Streaming transport.
+        /// See <see href="https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http">the protocol specification</see> for details about the Streamable HTTP transport.
+        /// </summary>
+        /// <param name="endpoints">The web application to attach MCP HTTP endpoints.</param>
+        /// <param name="pattern">The route pattern prefix to map to.</param>
+        /// <returns>Returns a builder for configuring additional endpoint conventions like authorization policies.</returns>
+        public static IRestServer MapMcp(this IRestServer server, string pattern = "")
+        {
+            var handler = server.Router.Services
+                              .BuildServiceProvider()
+                              .GetService<StreamableHttpHandler>() ??
+                          throw new InvalidOperationException("You must call WithHttpTransport(). Unable to find required services. Call builder.Services.AddMcpServer().WithHttpTransport() in application startup code.");
 
-        var prefix = pattern?.TrimEnd('/') ?? "";
-        server.Router.Register(
-            new Route(ctx => handler.HandleRequestAsync((HttpContext)ctx), "Get", prefix));
-        server.Router.Register(
-            new Route(ctx => handler.HandleRequestAsync((HttpContext)ctx), "Get", prefix + "/sse"));
-        server.Router.Register(
-            new Route(ctx => handler.HandleRequestAsync((HttpContext)ctx), "Post", prefix + "/message"));
-        return server;
+            var prefix = pattern?.TrimEnd('/') ?? "";
+            server.Router.Register(
+                new Route(ctx => handler.HandleRequestAsync((HttpContext)ctx), "Get", prefix));
+            server.Router.Register(
+                new Route(ctx => handler.HandleRequestAsync((HttpContext)ctx), "Get", prefix + "/sse"));
+            server.Router.Register(
+                new Route(ctx => handler.HandleRequestAsync((HttpContext)ctx), "Post", prefix + "/message"));
+
+            // Catch-all fallback for any unmatched GET routes -> 404 Not Found
+            server.Router.Register(
+                new Route(ctx => ctx.Response.SendResponseAsync(HttpStatusCode.NotFound), "Get", "/{*catchall}")
+            );
+
+            return server;
+        }
     }
 }

--- a/src/Grapevine.Extensions.Mcp/README.md
+++ b/src/Grapevine.Extensions.Mcp/README.md
@@ -1,0 +1,65 @@
+# Grapevine extensions for the MCP C# SDK
+
+[![NuGet preview version](https://img.shields.io/nuget/vpre/ModelContextProtocol.svg)](https://www.nuget.org/packages/ModelContextProtocol/absoluteLatest)
+
+The official C# SDK for the [Model Context Protocol](https://modelcontextprotocol.io/), enabling .NET applications, services, and libraries to implement and interact with MCP clients and servers. Please visit our [API documentation](https://modelcontextprotocol.github.io/csharp-sdk/api/ModelContextProtocol.html) for more details on available functionality.
+
+> [!NOTE]
+> This project is in preview; breaking changes can be introduced without prior notice.
+
+## About MCP
+
+The Model Context Protocol (MCP) is an open protocol that standardizes how applications provide context to Large Language Models (LLMs). It enables secure integration between LLMs and various data sources and tools.
+
+For more information about MCP:
+
+- [Official Documentation](https://modelcontextprotocol.io/)
+- [Protocol Specification](https://spec.modelcontextprotocol.io/)
+- [GitHub Organization](https://github.com/modelcontextprotocol)
+
+## Installation
+
+To get started, install the package from NuGet
+
+```
+dotnet new console
+dotnet add package Grapevine.Extensions.Mcp --prerelease
+```
+
+## Getting Started
+
+```csharp
+// Program.cs
+using System;
+using Grapevine;
+using Grapevine.Extensions.Mcp;
+using ModelContextProtocol.Server;
+
+[McpServerToolType]
+public static class EchoTool
+{
+    [McpServerTool, System.ComponentModel.Description("Echoes the message back to the client.")]
+    public static string Echo(string message) => $"hello {message}";
+}
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        var builder = new RestServerBuilder(
+            services => services.AddMcpServer()
+                                .WithHttpTransport()
+                                .WithToolsFromAssembly(),
+            server => server.Prefixes.Add("http://localhost:3001/")
+        );
+        var server = builder.Build();
+
+        server.MapMcp("/mcp");
+        server.Start();
+
+        Console.WriteLine("MCP server listening on http://localhost:3001/mcp");
+        Console.ReadLine();
+        server.Stop();
+    }
+}
+```

--- a/src/Grapevine.Extensions.Mcp/README.md
+++ b/src/Grapevine.Extensions.Mcp/README.md
@@ -49,6 +49,7 @@ class Program
         var builder = new RestServerBuilder(
             services => services.AddMcpServer()
                                 .WithHttpTransport()
+                                .WithPromptsFromAssembly()
                                 .WithToolsFromAssembly(),
             server => server.Prefixes.Add("http://localhost:3001/")
         );

--- a/src/Grapevine.Extensions.Mcp/StreamableHttpHandler.cs
+++ b/src/Grapevine.Extensions.Mcp/StreamableHttpHandler.cs
@@ -115,11 +115,11 @@ internal sealed class StreamableHttpHandler(
             return;
         }
 
-        // if (!httpMcpSession.HasSameUserId(context.User))
-        // {
-        //     await context.Response.SendResponseAsync(HttpStatusCode.Forbidden);
-        //     return;
-        // }
+        if (!httpMcpSession.HasSameUserId(context.Advanced.User))
+        {
+            await context.Response.SendResponseAsync(HttpStatusCode.Forbidden);
+            return;
+        }
 
         string json = new StreamReader(context.Advanced.Request.InputStream).ReadToEnd();
         var message = JsonSerializer.Deserialize<IJsonRpcMessage>(json, McpJsonUtilities.DefaultOptions);

--- a/src/Grapevine.Extensions.Mcp/StreamableHttpHandler.cs
+++ b/src/Grapevine.Extensions.Mcp/StreamableHttpHandler.cs
@@ -1,0 +1,152 @@
+﻿using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using ModelContextProtocol.Protocol.Messages;
+using ModelContextProtocol.Protocol.Transport;
+using ModelContextProtocol.Server;
+using ModelContextProtocol.Utils.Json;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Security.Cryptography;
+using System.IO;
+using System.Text;
+using System.Text.Json;
+
+namespace Grapevine.Extensions.Mcp;
+
+internal sealed class StreamableHttpHandler(
+    IOptions<McpServerOptions> mcpServerOptionsSnapshot,
+    IOptionsFactory<McpServerOptions> mcpServerOptionsFactory,
+    IOptions<HttpServerTransportOptions> httpMcpServerOptions,
+    IHostApplicationLifetime hostApplicationLifetime,
+    ILoggerFactory loggerFactory)
+{
+
+    private readonly ConcurrentDictionary<string, HttpMcpSession> _sessions = new(StringComparer.Ordinal);
+    private readonly ILogger _logger = loggerFactory.CreateLogger<StreamableHttpHandler>();
+
+    public async Task HandleRequestAsync(HttpContext context)
+    {
+        if (context.Request.HttpMethod == System.Net.Http.HttpMethod.Get)
+        {
+            await HandleSseRequestAsync(context);
+        }
+        else if (context.Request.HttpMethod == System.Net.Http.HttpMethod.Post)
+        {
+            await HandleMessageRequestAsync(context);
+        }
+        else
+        {
+            context.Response.StatusCode = HttpStatusCode.MethodNotAllowed;
+            await context.Response.SendResponseAsync(HttpStatusCode.MethodNotAllowed);
+        }
+    }
+
+    public async Task HandleSseRequestAsync(HttpContext context)
+    {
+        // If the server is shutting down, we need to cancel all SSE connections immediately without waiting for HostOptions.ShutdownTimeout
+        // which defaults to 30 seconds.
+        using var sseCts = CancellationTokenSource.CreateLinkedTokenSource(context.CancellationToken, hostApplicationLifetime.ApplicationStopping);
+        var cancellationToken = sseCts.Token;
+
+        var response = context.Response;
+        response.ContentType = "text/event-stream";
+        response.Headers["Cache-Control"] = "no-cache,no-store";
+
+        // Make sure we disable all response buffering for SSE
+        response.ContentEncoding = Encoding.UTF8;
+        // ASP.NET Core buffering disable removed for netstandard2.0 compatibility
+
+        var sessionId = MakeNewSessionId();
+        await using var transport = new SseResponseStreamTransport(context.Advanced.Response.OutputStream, $"message?sessionId={sessionId}");
+        var httpMcpSession = new HttpMcpSession(transport, context.Advanced.User);
+        if (!_sessions.TryAdd(sessionId, httpMcpSession))
+        {
+            Debug.Fail("Unreachable given good entropy!");
+            throw new InvalidOperationException($"Session with ID '{sessionId}' has already been created.");
+        }
+
+        try
+        {
+            var mcpServerOptions = mcpServerOptionsSnapshot.Value;
+            if (httpMcpServerOptions.Value.ConfigureSessionOptions is { } configureSessionOptions)
+            {
+                mcpServerOptions = mcpServerOptionsFactory.Create(Options.DefaultName);
+                await configureSessionOptions(context, mcpServerOptions, cancellationToken);
+            }
+
+            var transportTask = transport.RunAsync(cancellationToken);
+
+            try
+            {
+                await using var mcpServer = McpServerFactory.Create(transport, mcpServerOptions, loggerFactory, context.Services);
+
+                var runSessionAsync = httpMcpServerOptions.Value.RunSessionHandler ?? RunSessionAsync;
+                await runSessionAsync(context, mcpServer, cancellationToken);
+            }
+            finally
+            {
+                await transport.DisposeAsync();
+                await transportTask;
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // RequestAborted always triggers when the client disconnects before a complete response body is written,
+            // but this is how SSE connections are typically closed.
+        }
+        finally
+        {
+            _sessions.TryRemove(sessionId, out _);
+        }
+    }
+
+    public async Task HandleMessageRequestAsync(HttpContext context)
+    {
+        if (string.IsNullOrEmpty(context.Request.QueryString.Get("sessionId")))
+        {
+            await context.Response.SendResponseAsync(HttpStatusCode.BadRequest, "Missing sessionId query parameter.");
+            return;
+        }
+        var sessionId = context.Request.QueryString.Get("sessionId");
+        if (!_sessions.TryGetValue(sessionId, out var httpMcpSession))
+        {
+            await context.Response.SendResponseAsync(HttpStatusCode.BadRequest, "Invalid sessionId");
+            return;
+        }
+
+        // if (!httpMcpSession.HasSameUserId(context.User))
+        // {
+        //     await context.Response.SendResponseAsync(HttpStatusCode.Forbidden);
+        //     return;
+        // }
+
+        string json = new StreamReader(context.Advanced.Request.InputStream).ReadToEnd();
+        var message = JsonSerializer.Deserialize<IJsonRpcMessage>(json, McpJsonUtilities.DefaultOptions);
+        if (message is null)
+        {
+            await context.Response.SendResponseAsync(HttpStatusCode.BadRequest, "No message in request body.");
+            return;
+        }
+
+        await httpMcpSession.Transport.OnMessageReceivedAsync(message, context.CancellationToken);
+        context.Response.StatusCode = HttpStatusCode.Accepted;
+        await context.Response.SendResponseAsync(HttpStatusCode.Accepted);
+    }
+
+    private static Task RunSessionAsync(HttpContext httpContext, IMcpServer session, CancellationToken requestAborted)
+        => session.RunAsync(requestAborted);
+
+    private static string MakeNewSessionId()
+    {
+        {
+            var buffer = new byte[16];
+            using (var rng = RandomNumberGenerator.Create())
+            {
+                rng.GetBytes(buffer);
+            }
+            string base64 = Convert.ToBase64String(buffer);
+            return base64.TrimEnd('=').Replace('+', '-').Replace('/', '_');
+        }
+    }
+}

--- a/src/Grapevine.Extensions.Mcp/StreamableHttpHandler.cs
+++ b/src/Grapevine.Extensions.Mcp/StreamableHttpHandler.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.Extensions.Hosting;
+﻿using System;
+
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using ModelContextProtocol.Protocol.Messages;
@@ -7,146 +9,163 @@ using ModelContextProtocol.Server;
 using ModelContextProtocol.Utils.Json;
 using System.Collections.Concurrent;
 using System.Diagnostics;
-using System.Security.Cryptography;
 using System.IO;
+using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
 
-namespace Grapevine.Extensions.Mcp;
-
-internal sealed class StreamableHttpHandler(
-    IOptions<McpServerOptions> mcpServerOptionsSnapshot,
-    IOptionsFactory<McpServerOptions> mcpServerOptionsFactory,
-    IOptions<HttpServerTransportOptions> httpMcpServerOptions,
-    IHostApplicationLifetime hostApplicationLifetime,
-    ILoggerFactory loggerFactory)
+namespace Grapevine.Extensions.Mcp
 {
-
-    private readonly ConcurrentDictionary<string, HttpMcpSession> _sessions = new(StringComparer.Ordinal);
-    private readonly ILogger _logger = loggerFactory.CreateLogger<StreamableHttpHandler>();
-
-    public async Task HandleRequestAsync(HttpContext context)
+    internal sealed class StreamableHttpHandler
     {
-        if (context.Request.HttpMethod == System.Net.Http.HttpMethod.Get)
-        {
-            await HandleSseRequestAsync(context);
-        }
-        else if (context.Request.HttpMethod == System.Net.Http.HttpMethod.Post)
-        {
-            await HandleMessageRequestAsync(context);
-        }
-        else
-        {
-            context.Response.StatusCode = HttpStatusCode.MethodNotAllowed;
-            await context.Response.SendResponseAsync(HttpStatusCode.MethodNotAllowed);
-        }
-    }
 
-    public async Task HandleSseRequestAsync(HttpContext context)
-    {
-        // If the server is shutting down, we need to cancel all SSE connections immediately without waiting for HostOptions.ShutdownTimeout
-        // which defaults to 30 seconds.
-        using var sseCts = CancellationTokenSource.CreateLinkedTokenSource(context.CancellationToken, hostApplicationLifetime.ApplicationStopping);
-        var cancellationToken = sseCts.Token;
+        private readonly ConcurrentDictionary<string, HttpMcpSession> _sessions = new ConcurrentDictionary<string, HttpMcpSession>(StringComparer.Ordinal);
+        private readonly ILogger _logger;
+        private readonly IOptions<McpServerOptions> _mcpServerOptionsSnapshot;
+        private readonly IOptionsFactory<McpServerOptions> _mcpServerOptionsFactory;
+        private readonly IOptions<HttpServerTransportOptions> _httpMcpServerOptions;
+        private readonly IHostApplicationLifetime _hostApplicationLifetime;
+        private readonly ILoggerFactory _loggerFactory;
 
-        var response = context.Response;
-        response.ContentType = "text/event-stream";
-        response.Headers["Cache-Control"] = "no-cache,no-store";
-
-        // Make sure we disable all response buffering for SSE
-        response.ContentEncoding = Encoding.UTF8;
-        // ASP.NET Core buffering disable removed for netstandard2.0 compatibility
-
-        var sessionId = MakeNewSessionId();
-        await using var transport = new SseResponseStreamTransport(context.Advanced.Response.OutputStream, $"message?sessionId={sessionId}");
-        var httpMcpSession = new HttpMcpSession(transport, context.Advanced.User);
-        if (!_sessions.TryAdd(sessionId, httpMcpSession))
+        public StreamableHttpHandler(IOptions<McpServerOptions> mcpServerOptionsSnapshot,
+            IOptionsFactory<McpServerOptions> mcpServerOptionsFactory,
+            IOptions<HttpServerTransportOptions> httpMcpServerOptions,
+            IHostApplicationLifetime hostApplicationLifetime,
+            ILoggerFactory loggerFactory)
         {
-            Debug.Fail("Unreachable given good entropy!");
-            throw new InvalidOperationException($"Session with ID '{sessionId}' has already been created.");
+            _mcpServerOptionsSnapshot = mcpServerOptionsSnapshot;
+            _mcpServerOptionsFactory = mcpServerOptionsFactory;
+            _httpMcpServerOptions = httpMcpServerOptions;
+            _hostApplicationLifetime = hostApplicationLifetime;
+            _loggerFactory = loggerFactory;
+            _logger = loggerFactory.CreateLogger<StreamableHttpHandler>();
         }
 
-        try
+        public async Task HandleRequestAsync(HttpContext context)
         {
-            var mcpServerOptions = mcpServerOptionsSnapshot.Value;
-            if (httpMcpServerOptions.Value.ConfigureSessionOptions is { } configureSessionOptions)
+            if (context.Request.HttpMethod == System.Net.Http.HttpMethod.Get)
             {
-                mcpServerOptions = mcpServerOptionsFactory.Create(Options.DefaultName);
-                await configureSessionOptions(context, mcpServerOptions, cancellationToken);
+                await HandleSseRequestAsync(context);
             }
+            else if (context.Request.HttpMethod == System.Net.Http.HttpMethod.Post)
+            {
+                await HandleMessageRequestAsync(context);
+            }
+            else
+            {
+                context.Response.StatusCode = HttpStatusCode.MethodNotAllowed;
+                await context.Response.SendResponseAsync(HttpStatusCode.MethodNotAllowed);
+            }
+        }
 
-            var transportTask = transport.RunAsync(cancellationToken);
+        public async Task HandleSseRequestAsync(HttpContext context)
+        {
+            // If the server is shutting down, we need to cancel all SSE connections immediately without waiting for HostOptions.ShutdownTimeout
+            // which defaults to 30 seconds.
+            using var sseCts = CancellationTokenSource.CreateLinkedTokenSource(context.CancellationToken, _hostApplicationLifetime.ApplicationStopping);
+            var cancellationToken = sseCts.Token;
+
+            var response = context.Response;
+            response.ContentType = "text/event-stream";
+            response.Headers["Cache-Control"] = "no-cache,no-store";
+
+            // Make sure we disable all response buffering for SSE
+            response.ContentEncoding = Encoding.UTF8;
+            // ASP.NET Core buffering disable removed for netstandard2.0 compatibility
+
+            var sessionId = MakeNewSessionId();
+            await using var transport = new SseResponseStreamTransport(context.Advanced.Response.OutputStream, $"message?sessionId={sessionId}");
+            var httpMcpSession = new HttpMcpSession(transport, context.Advanced.User);
+            if (!_sessions.TryAdd(sessionId, httpMcpSession))
+            {
+                Debug.Fail("Unreachable given good entropy!");
+                throw new InvalidOperationException($"Session with ID '{sessionId}' has already been created.");
+            }
 
             try
             {
-                await using var mcpServer = McpServerFactory.Create(transport, mcpServerOptions, loggerFactory, context.Services);
+                var mcpServerOptions = _mcpServerOptionsSnapshot.Value;
+                if (_httpMcpServerOptions.Value.ConfigureSessionOptions is { } configureSessionOptions)
+                {
+                    mcpServerOptions = _mcpServerOptionsFactory.Create(Options.DefaultName);
+                    await configureSessionOptions(context, mcpServerOptions, cancellationToken);
+                }
 
-                var runSessionAsync = httpMcpServerOptions.Value.RunSessionHandler ?? RunSessionAsync;
-                await runSessionAsync(context, mcpServer, cancellationToken);
+                var transportTask = transport.RunAsync(cancellationToken);
+
+                try
+                {
+                    await using var mcpServer = McpServerFactory.Create(transport, mcpServerOptions, _loggerFactory, context.Services);
+
+                    var runSessionAsync = _httpMcpServerOptions.Value.RunSessionHandler ?? RunSessionAsync;
+                    await runSessionAsync(context, mcpServer, cancellationToken);
+                }
+                finally
+                {
+                    await transport.DisposeAsync();
+                    await transportTask;
+                }
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                // RequestAborted always triggers when the client disconnects before a complete response body is written,
+                // but this is how SSE connections are typically closed.
             }
             finally
             {
-                await transport.DisposeAsync();
-                await transportTask;
+                _sessions.TryRemove(sessionId, out _);
             }
         }
-        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-        {
-            // RequestAborted always triggers when the client disconnects before a complete response body is written,
-            // but this is how SSE connections are typically closed.
-        }
-        finally
-        {
-            _sessions.TryRemove(sessionId, out _);
-        }
-    }
 
-    public async Task HandleMessageRequestAsync(HttpContext context)
-    {
-        if (string.IsNullOrEmpty(context.Request.QueryString.Get("sessionId")))
+        public async Task HandleMessageRequestAsync(HttpContext context)
         {
-            await context.Response.SendResponseAsync(HttpStatusCode.BadRequest, "Missing sessionId query parameter.");
-            return;
-        }
-        var sessionId = context.Request.QueryString.Get("sessionId");
-        if (!_sessions.TryGetValue(sessionId, out var httpMcpSession))
-        {
-            await context.Response.SendResponseAsync(HttpStatusCode.BadRequest, "Invalid sessionId");
-            return;
-        }
-
-        if (!httpMcpSession.HasSameUserId(context.Advanced.User))
-        {
-            await context.Response.SendResponseAsync(HttpStatusCode.Forbidden);
-            return;
-        }
-
-        string json = new StreamReader(context.Advanced.Request.InputStream).ReadToEnd();
-        var message = JsonSerializer.Deserialize<IJsonRpcMessage>(json, McpJsonUtilities.DefaultOptions);
-        if (message is null)
-        {
-            await context.Response.SendResponseAsync(HttpStatusCode.BadRequest, "No message in request body.");
-            return;
-        }
-
-        await httpMcpSession.Transport.OnMessageReceivedAsync(message, context.CancellationToken);
-        context.Response.StatusCode = HttpStatusCode.Accepted;
-        await context.Response.SendResponseAsync(HttpStatusCode.Accepted);
-    }
-
-    private static Task RunSessionAsync(HttpContext httpContext, IMcpServer session, CancellationToken requestAborted)
-        => session.RunAsync(requestAborted);
-
-    private static string MakeNewSessionId()
-    {
-        {
-            var buffer = new byte[16];
-            using (var rng = RandomNumberGenerator.Create())
+            if (string.IsNullOrEmpty(context.Request.QueryString.Get("sessionId")))
             {
-                rng.GetBytes(buffer);
+                await context.Response.SendResponseAsync(HttpStatusCode.BadRequest, "Missing sessionId query parameter.");
+                return;
             }
-            string base64 = Convert.ToBase64String(buffer);
-            return base64.TrimEnd('=').Replace('+', '-').Replace('/', '_');
+            var sessionId = context.Request.QueryString.Get("sessionId");
+            if (!_sessions.TryGetValue(sessionId, out var httpMcpSession))
+            {
+                await context.Response.SendResponseAsync(HttpStatusCode.BadRequest, "Invalid sessionId");
+                return;
+            }
+
+            if (!httpMcpSession.HasSameUserId(context.Advanced.User))
+            {
+                await context.Response.SendResponseAsync(HttpStatusCode.Forbidden);
+                return;
+            }
+
+            string json = new StreamReader(context.Advanced.Request.InputStream).ReadToEnd();
+            var message = JsonSerializer.Deserialize<IJsonRpcMessage>(json, McpJsonUtilities.DefaultOptions);
+            if (message is null)
+            {
+                await context.Response.SendResponseAsync(HttpStatusCode.BadRequest, "No message in request body.");
+                return;
+            }
+
+            await httpMcpSession.Transport.OnMessageReceivedAsync(message, context.CancellationToken);
+            context.Response.StatusCode = HttpStatusCode.Accepted;
+            await context.Response.SendResponseAsync(HttpStatusCode.Accepted);
+        }
+
+        private static Task RunSessionAsync(HttpContext httpContext, IMcpServer session, CancellationToken requestAborted)
+            => session.RunAsync(requestAborted);
+
+        private static string MakeNewSessionId()
+        {
+            {
+                var buffer = new byte[16];
+                using (var rng = RandomNumberGenerator.Create())
+                {
+                    rng.GetBytes(buffer);
+                }
+                string base64 = Convert.ToBase64String(buffer);
+                return base64.TrimEnd('=').Replace('+', '-').Replace('/', '_');
+            }
         }
     }
 }

--- a/src/Grapevine.Tests/Grapevine.Tests.csproj
+++ b/src/Grapevine.Tests/Grapevine.Tests.csproj
@@ -21,6 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Grapevine.Extensions.Mcp\Grapevine.Extensions.Mcp.csproj" />
     <ProjectReference Include="..\Grapevine\Grapevine.csproj" />
     <ProjectReference Include="..\Grapeseed\Grapeseed.csproj" />
   </ItemGroup>

--- a/src/Grapevine.Tests/McpServerWithHttpTransportTests.cs
+++ b/src/Grapevine.Tests/McpServerWithHttpTransportTests.cs
@@ -47,6 +47,7 @@ namespace Grapevine.Tests
         {
             var response = await _client.GetAsync("/mcp", HttpCompletionOption.ResponseHeadersRead);
             response.StatusCode.ShouldBe(System.Net.HttpStatusCode.OK);
+            response.Content.Headers.ContentType.ShouldNotBeNull();
             response.Content.Headers.ContentType.MediaType.ShouldBe("text/event-stream");
         }
 
@@ -55,6 +56,7 @@ namespace Grapevine.Tests
         {
             var response = await _client.GetAsync("/mcp/sse", HttpCompletionOption.ResponseHeadersRead);
             response.StatusCode.ShouldBe(System.Net.HttpStatusCode.OK);
+            response.Content.Headers.ContentType.ShouldNotBeNull();
             response.Content.Headers.ContentType.MediaType.ShouldBe("text/event-stream");
         }
 

--- a/src/Grapevine.Tests/McpServerWithHttpTransportTests.cs
+++ b/src/Grapevine.Tests/McpServerWithHttpTransportTests.cs
@@ -117,11 +117,17 @@ namespace Grapevine.Tests
         }
     }
     
-    [McpServerToolType]
-    public sealed class EchoTool
+    public abstract class EchoToolBase
     {
         [McpServerTool, Description("Echoes the input back to the client.")]
-        public static string Echo(string message) => $"hello {message}";
+        public abstract string Echo(string message);
+    }
+
+    [McpServerToolType]
+    public class EchoTool : EchoToolBase
+    {
+        public override string Echo(string message) => $"hello {message}";
+
     }
 
     internal class NullHostApplicationLifetime : IHostApplicationLifetime

--- a/src/Grapevine.Tests/McpServerWithHttpTransportTests.cs
+++ b/src/Grapevine.Tests/McpServerWithHttpTransportTests.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+using Grapevine.Extensions.Mcp;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+
+using Xunit;
+using Shouldly;
+
+namespace Grapevine.Tests
+{
+    public class McpServerWithHttpTransportTests : IDisposable
+    {
+        private readonly IRestServer _server;
+        private readonly HttpClient _client;
+
+        public McpServerWithHttpTransportTests()
+        {
+            var port = GetFreePort();
+            var builder = RestServerBuilder.UseDefaults();
+            builder.Services.AddMcpServer()
+                .WithHttpTransport()
+                .WithToolsFromAssembly();
+            // Register a no-op host lifetime so StreamableHttpHandler can resolve IHostApplicationLifetime during tests
+            builder.Services.TryAddSingleton<IHostApplicationLifetime, NullHostApplicationLifetime>();
+            _server = builder.Build();
+            _server.Prefixes.Add($"http://localhost:{port}/");
+            _server.MapMcp("/mcp");
+            _server.Start();
+            _client = new HttpClient { BaseAddress = new Uri($"http://localhost:{port}") };
+        }
+
+        public void Dispose()
+        {
+            _client.Dispose();
+            _server.Stop();
+        }
+
+        [Fact]
+        public async Task GetMcp_ReturnsEventStream()
+        {
+            var response = await _client.GetAsync("/mcp", HttpCompletionOption.ResponseHeadersRead);
+            response.StatusCode.ShouldBe(System.Net.HttpStatusCode.OK);
+            response.Content.Headers.ContentType.MediaType.ShouldBe("text/event-stream");
+        }
+
+        [Fact]
+        public async Task GetMcpSse_ReturnsEventStream()
+        {
+            var response = await _client.GetAsync("/mcp/sse", HttpCompletionOption.ResponseHeadersRead);
+            response.StatusCode.ShouldBe(System.Net.HttpStatusCode.OK);
+            response.Content.Headers.ContentType.MediaType.ShouldBe("text/event-stream");
+        }
+
+        [Fact]
+        public async Task InvalidRoute_ReturnsNotFound()
+        {
+            // Any path other than /mcp or /mcp/sse should return 404
+            var response = await _client.GetAsync("/invalid", HttpCompletionOption.ResponseHeadersRead);
+            response.StatusCode.ShouldBe(System.Net.HttpStatusCode.NotFound);
+        }
+
+        private static int GetFreePort()
+        {
+            var listener = new TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+            var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            listener.Stop();
+            return port;
+        }
+    }
+
+    internal class NullHostApplicationLifetime : IHostApplicationLifetime
+    {
+        public CancellationToken ApplicationStarted => CancellationToken.None;
+        public CancellationToken ApplicationStopping => CancellationToken.None;
+        public CancellationToken ApplicationStopped => CancellationToken.None;
+        public void StopApplication() { }
+    }
+}

--- a/src/Samples/Startup.cs
+++ b/src/Samples/Startup.cs
@@ -1,6 +1,9 @@
 using System;
 using System.IO;
 using Grapevine;
+// Uncomment the following line to enable MCP extensions via Grapevine.Extensions.Mcp
+//     using Grapevine.Extensions.Mcp;
+
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -34,6 +37,11 @@ namespace Samples
                 c.DefaultRequestHeaders.Add("Accept", "application/vnd.github.v3+json");
                 c.DefaultRequestHeaders.Add("User-Agent", "Grapevine-Client");
             });
+
+            // Uncomment the following lines to register and configure the MCP server
+            //     services.AddMcpServer()
+            //         .WithHttpTransport()
+            //         .WithToolsFromAssembly();
         }
 
         public void ConfigureServer(IRestServer server)
@@ -53,6 +61,9 @@ namespace Samples
 
             /* Configure Router Options (if supported by your router implementation) */
             server.Router.Options.SendExceptionMessages = true;
+
+            // Uncomment the following line to map MCP endpoints on the server
+            //     server.MapMcp();
         }
     }
 }

--- a/src/Samples/Startup.cs
+++ b/src/Samples/Startup.cs
@@ -41,6 +41,7 @@ namespace Samples
             // Uncomment the following lines to register and configure the MCP server
             //     services.AddMcpServer()
             //         .WithHttpTransport()
+            //         .WithPromptsFromAssembly()
             //         .WithToolsFromAssembly();
         }
 


### PR DESCRIPTION
Introduces an extension enabling Grapevine servers to handle Model Context Protocol (MCP) requests.

This extension provides:
- Support for the MCP HTTP Streaming transport.
- Methods for configuring HTTP MCP servers via dependency injection.
- Route registration for handling GET and POST requests related to MCP.

This allows Grapevine servers to act as MCP endpoints, facilitating communication with LLMs through the MCP protocol.